### PR TITLE
Added rule to download GTF files.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,7 +27,9 @@ fastq10x_patterns:  # names, regex, allowed substitution mismatches
 spikein_genome:
   species: human
   fasta: ftp://ftp.ensembl.org/pub/release-98/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz
-  
+  gtf: ftp://ftp.ensembl.org/pub/release-98/gtf/homo_sapiens/Homo_sapiens.GRCh38.98.gtf.gz
+
 cell_genome:
   species: canine
   fasta: ftp://ftp.ensembl.org/pub/release-98/fasta/canis_familiaris/dna/Canis_familiaris.CanFam3.1.dna.toplevel.fa.gz
+  gtf: ftp://ftp.ensembl.org/pub/release-98/gtf/canis_familiaris/Canis_familiaris.CanFam3.1.98.gtf.gz


### PR DESCRIPTION
Made a rule to download gene set GTF files. This is essentially a direct copy of the rule that downloads genome FASTA files.

The only change I made was moving the `genome` variable to its own section near the top of the Snakemake file, under "Global variables statically defined".

Closes Issue #6.