### PR TITLE
only gunzip cell barcodes if needed

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,8 +27,8 @@ viral_genbank: data/flu_sequences/flu-CA09.gb
 # file giving nucleotide identities at viral tag sites
 viral_tags: data/flu_sequences/flu-CA09_viral_tags.yaml
 
-# FTP location of 10X barcode whitelist: **this is for the v3 kit**
-cb_whitelist_10x_ftp: https://github.com/10XGenomics/cellranger/raw/master/lib/python/cellranger/barcodes/3M-february-2018.txt.gz
+# URL location of 10X barcode whitelist: **this is for the v3 kit**
+cb_whitelist_10x_url: https://github.com/10XGenomics/cellranger/raw/master/lib/python/cellranger/barcodes/3M-february-2018.txt.gz
 cb_whitelist_10x: results/aligned_fastq10x/cb_whitelist_10x.txt
 
 cb_len_10x: 16  # length of 10X cell barcode

--- a/rules/align_fastq10x.smk
+++ b/rules/align_fastq10x.smk
@@ -91,5 +91,13 @@ rule align_fastq10x:
 rule get_cb_whitelist_10x:
     """Get whitelisted 10X cellbarcodes."""
     output: config['cb_whitelist_10x']
-    params: ftp=config['cb_whitelist_10x_ftp']
-    shell: "wget -O - {params.ftp} | gunzip -c > {output}"
+    params: url=config['cb_whitelist_10x_url']
+    shell:
+        """
+        if [[ {params.url} == *.gz ]]
+        then
+            wget -O - {params.url} | gunzip -c > {output}
+        else
+            wget -O - {params.url} > {output}
+        fi
+        """


### PR DESCRIPTION
This makes the same rule work with the v3 (gzipped)
and v2 (not gzipped) 10X barcode whitelists.