### PR TITLE
Removed irrelevant pilot samples. Retained hashing and scPP samples. …

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,34 +43,7 @@ umi_len_10x: 12  # length of 10X UMI: **this is for the v3 kit**
 #----------------------------------------------------------------------------
 experiments:
 
-  hashing_wt_rapidpilot:
-    description: Single-cell transcriptomics using a small-scale pilot rescue
-                 of the wildtype viral tag variant.
-    lab_notes: https://benchling.com/s/etr-Q28fCd1kprRNxAd0v5Hg
-    expect_ncells: 2000
-    transcriptomics:
-      2019-12-03:
-        index: SI-GA-A3
-        bcl_folder: /shared/ngs/illumina/bloom_lab/191203_M03100_0504_000000000-CNCN9/
-        lane: '*'
-
-  hashing_trial1:
-    description: Single-cell transcriptomics using the wildtype and dblSyn viral
-                 tag variants. Infection volume was chosen based on HA expression
-                 measured by flow cytometry.
-    lab_notes: https://benchling.com/s/etr-i9I0yHiFb0P8wHCxosim
-    expect_ncells: 2000
-    transcriptomics:
-      2020-01-16:
-        index: SI-GA-A4
-        bcl_folder: /shared/ngs/illumina/bloom_lab/200128_M03100_0528_000000000-CRC4G/
-        lane: '*'
-      2020-02-18:
-        index: SI-GA-A4
-        bcl_folder: /shared/ngs/illumina/bloom_lab/200218_D00300_0910_AHCHHJBCX3/Raw/
-        lane: 2
-
-  hashing_trial2:
+  hashing_lowMOI:
     description: Single-cell transcriptomics using the wildtype and dblySyn viral
                  tag variants. Infection volume was chosen based on the results
                  of `hashing_trial1` and flow cytometry. The incolum volume for
@@ -92,7 +65,7 @@ experiments:
         bcl_folder: /shared/ngs/illumina/bloom_lab/bloom_lab/200826_D00300_1040_BHHGLWBCX3/raw/200826_D00300_1040_BHHGLWBCX3/
         lane: '*'
 
-  hashing_trial3_withNH4Cl:
+  hashing_highMOI:
     description: Single-cell transcriptomics using the wildtype and dblSyn viral
                  tag variants at a high MOI. Infection volume was based on the results of
                  `hashing_trial2`.
@@ -106,19 +79,6 @@ experiments:
       2020-08-26:
         index: SI-GA-B5
         bcl_folder: /shared/ngs/illumina/bloom_lab/bloom_lab/200826_D00300_1040_BHHGLWBCX3/raw/200826_D00300_1040_BHHGLWBCX3/
-        lane: '*'
-
-  hashing_trial3_noNH4Cl:
-    description: Single-cell transcriptomics performed *without* NH4Cl treatment. Used
-                 wildtype and dblSyn viral tag variants at high MOI. Infection volume was
-                 based on the results of `hashing_trial2`. Performed in conjunction with
-                 `hashing_trial3_withNH4Cl`.
-    lab_notes: https://benchling.com/s/etr-ToK66qT0Mfmf6FsexKo4
-    expect_ncells: 5000
-    transcriptomics:
-      2020-07-24:
-        index: SI-GA-B4
-        bcl_folder: /shared/ngs/illumina/bloom_lab/200724_M03100_0593_000000000-J33YK/
         lane: '*'
 
   scProgenyProduction_trial1:


### PR DESCRIPTION
…Renamed hashing samples to highMOI and lowMOI

I simply modified `config.yml` to remove samples that are no longer important. I kept the scProgenyProduction samples (both trials) and the two hashing samples.

`hashing_trial2` became `hashing_lowMOI` and
`hashing_trial3_withNH4Cl` became `hashing_highMOI`

This pull request closes issue #56.