### PR TITLE
used `conda:` to specify per-rule conda env

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This repository is organized as followed (based loosely on [this example snakema
 
  - [Snakefile] is the [snakemake] file that runs the analysis.
 
+ - [environment.yml](environment.yml) and [environment_unpinned.yml](environment_unpinned.yml) give the version pinned and unpinned [conda] environment for the analysis.
+
  - [config.yaml](config.yaml) contains the configuration for the analysis.
 
  - [cluster.yaml](cluster.yaml) contains the cluster configuration for running tha analysis on the Fred Hutch cluster.
@@ -41,15 +43,8 @@ Otherwise you need to first build the [conda] environment from [environment.yml]
 In addition to building and activating the [conda] environment, you also need to install [cellranger] and [bcl2fastq] into the current path; the current analysis uses [cellranger] version 4.0.0 and [bcl2fastq] version 2.20.
 
 ### Run the analysis
-Once the *barcoded_flu_pdmH1N1* [conda] environment and other software have been activated, simply run [Snakefile] with the command:
-
-    snakemake
-
-And then generate the [snakemake report], at `./results/report.html` with:
-
-    snakemake --report results/report.html
-
-To run on the Hutch cluster using [sbatch](sbatch) and the cluster configuration in [cluster.yaml](cluster.yaml), run the bash script [run_Hutch_cluster.bash](run_Hutch_cluster.bash).
+Once the *barcoded_flu_pdmH1N1* [conda] environment and other software have been activated, simply enter the commands to run [Snakefile] and then generate a [snakemake report], at `./results/report.html`.
+These commands with the configuration for the Fred Hutch cluster are in the shell script. [run_Hutch_cluster.bash](run_Hutch_cluster.bash).
 You probably want to submit the script itself via [sbatch](sbatch), using:
 
     sbatch run_Hutch_cluster.sbatch

--- a/environment.yml
+++ b/environment.yml
@@ -385,5 +385,3 @@ dependencies:
     - pox==0.2.8
     - ppft==1.6.6.2
     - regex==2020.10.11
-prefix: /fh/fast/bloom_j/software/miniconda3/envs/barcoded_flu_pdmH1N1
-

--- a/rules/align_fastq10x.smk
+++ b/rules/align_fastq10x.smk
@@ -17,6 +17,7 @@ rule qc_transcript_alignments:
     log:
         notebook=join(config['aligned_fastq10x_dir'], "{expt}",
                       'qc_transcript_alignments.ipynb')
+    conda: '../environment.yml'
     notebook:
         '../notebooks/qc_transcript_alignments.py.ipynb'
 
@@ -104,6 +105,7 @@ rule get_cb_whitelist_10x:
     """Get whitelisted 10X cellbarcodes."""
     output: config['cb_whitelist_10x']
     params: url=config['cb_whitelist_10x_url']
+    conda: '../environment.yml'
     shell:
         """
         if [[ {params.url} == *.gz ]]

--- a/rules/fastq10x.smk
+++ b/rules/fastq10x.smk
@@ -15,6 +15,7 @@ rule qc_fastq10x:
                        category="{expt}")
     log:
         notebook=join(config['fastq10x_dir'], "{expt}_qc_fastq10x.ipynb")
+    conda: '../environment.yml'
     notebook:
         '../notebooks/qc_fastq10x.py.ipynb'
 

--- a/rules/star_refgenome.smk
+++ b/rules/star_refgenome.smk
@@ -5,6 +5,7 @@ rule get_cell_genome:
     """Get the FASTA file for the cellular genome."""
     output: join(config['genome_dir'], 'cell_genome.fasta')
     params: ftp=config['cell_genome_ftp']
+    conda: '../environment.yml'
     shell: "wget -O - {params.ftp} | gunzip -c > {output}"
 
 
@@ -12,6 +13,7 @@ rule get_cell_gtf:
     """Get the GTF file for the cellular genome."""
     output: join(config['genome_dir'], 'cell_gtf.gtf')
     params: ftp=config['cell_gtf_ftp']
+    conda: '../environment.yml'
     shell: "wget -O - {params.ftp} | gunzip -c > {output}"
 
 
@@ -26,6 +28,7 @@ rule make_refgenome:
         concat_gtf=join(config['genome_dir'], 'cell_and_virus_gtf.gtf'),
         genomeDir=directory(config['refgenome'])
     threads: config['max_cpus']
+    conda: '../environment.yml'
     shell:
         """
         cat {input.cell_gtf} {input.viral_gtf} > {output.concat_gtf}

--- a/rules/utils.smk
+++ b/rules/utils.smk
@@ -5,5 +5,6 @@ rule index_bam:
     """Index a BAM file using `samtools`."""
     input: "{bamfile_base}.bam"
     output: "{bamfile_base}.bam.bai"
+    conda: '../environment.yml'
     shell:
         """samtools index {input} {output}"""

--- a/rules/viral_fastq10x.smk
+++ b/rules/viral_fastq10x.smk
@@ -18,6 +18,7 @@ rule viral_transcript_coverage:
     log:
         notebook=join(config['viral_fastq10x_dir'],
                       "{expt}_viral_transcript_coverage.py.ipynb")
+    conda: '../environment.yml'
     notebook:
         '../notebooks/viral_transcript_coverage.py.ipynb'
 
@@ -38,6 +39,7 @@ rule viral_barcodes_by_cell:
     log:
         notebook=join(config['viral_fastq10x_dir'],
                       "{expt}_viral_barcodes_by_cell.ipynb")
+    conda: '../environment.yml'
     notebook:
         '../notebooks/viral_barcodes_by_cell.py.ipynb'
 
@@ -58,6 +60,7 @@ rule viral_tags_by_cell:
     log:
         notebook=join(config['viral_fastq10x_dir'],
                       "{expt}_viral_tags_by_cell.ipynb")
+    conda: '../environment.yml'
     notebook:
         '../notebooks/viral_tags_by_cell.py.ipynb'
 
@@ -79,6 +82,7 @@ rule viral_barcodes_in_transcripts:
     log:
         notebook=join(config['viral_fastq10x_dir'],
                       "{expt}_viral_barcodes_in_transcripts.ipynb")
+    conda: '../environment.yml'
     notebook:
         '../notebooks/viral_barcodes_in_transcripts.py.ipynb'
 
@@ -101,6 +105,7 @@ rule viral_tags_in_transcripts:
     log:
         notebook=join(config['viral_fastq10x_dir'],
                       "{expt}_viral_tags_in_transcripts.ipynb")
+    conda: '../environment.yml'
     notebook:
         '../notebooks/viral_tags_in_transcripts.py.ipynb'
 

--- a/run_Hutch_cluster.bash
+++ b/run_Hutch_cluster.bash
@@ -10,7 +10,6 @@ snakemake \
     --cluster "sbatch -c {cluster.cpus} -t {cluster.time} -J {cluster.name}" \
     --latency-wait 30 \
     --use-conda \
-    --conda-prefix /fh/fast/bloom_j/software/miniconda3/envs/barcoded_flu_pdmH1N1 \
     -R `snakemake --list-input-changes`  # https://snakemake.readthedocs.io/en/stable/project_info/faq.html#snakemake-does-not-trigger-re-runs-if-i-add-additional-input-files-what-can-i-do
 echo "Run of snakemake complete."
 


### PR DESCRIPTION
@dbacsik, this commit accomplishes what you suggested in #61. I originally was poo-poo-ing the idea in that issue, but I read more about `snakemake` and `conda`, and agree you are correct. So now each rule specifies the `conda:` directive as you suggested.

Can you review and merge this?