### PR TITLE
Added access function to return viral barcode FASTQs  in dataframe

### DIFF
--- a/pymodules/experiments.py
+++ b/pymodules/experiments.py
@@ -180,5 +180,6 @@ class Experiments:
         files for that experiment. Each FASTQ path is
         annotated with source, tag, gene, replicate, and run.
         """
+        assert expt in self.experiments, f"invalid `expt` {expt}"
         return (self.viral_barcodes_df
                 .query('experiment == @expt')


### PR DESCRIPTION
This pull request adds a function to the `Experiments` class to return all of the viral barcode FASTQs for a given experiment in a pandas dataframe.