### PR TITLE
Put notebook in log_dir

### DIFF
--- a/rules/viral_progeny.smk
+++ b/rules/viral_progeny.smk
@@ -17,7 +17,7 @@ rule viral_barcodes_in_progeny:
         viral_barcode_upstream_length=config['viral_barcode_upstream_length'],
         barcoded_viral_genes=barcoded_viral_genes
     log:
-        notebook=join(config['viral_progeny_dir'],
+        notebook=join(config['log_dir'],
                       "{expt}_viral_barcodes_in_progeny.py.ipynb")
     conda: '../environment.yml'
     notebook:


### PR DESCRIPTION
@jbloom This simple pull request puts the processed `viral_progeny` notebook for each experiment in the `log` directory. All the other rules appear to store their processed notebooks there. If for some reason this notebook should be stored in the `viral_progeny` directory, please decline this pull request.