### PR TITLE
log output of `build_ccs`

### DIFF
--- a/rules/pacbio_analysis.smk
+++ b/rules/pacbio_analysis.smk
@@ -36,11 +36,13 @@ rule build_ccs:
         ccs_min_rq=config['ccs_min_rq'],
     threads: config['max_cpus'],
     conda: '../environment.yml'
-    log: join(config['log_dir'], "{pacbio_run}_build_ccs.log")
+    log: join(config['log_dir'], "build_ccs_{pacbio_run}.log")
     shell:
         """
         ccs \
             --report-file {output.ccs_report} \
+            --log-level INFO \
+            --log-file {log} \
             --num-threads {threads} \
             --min-length {params.ccs_min_length} \
             --max-length {params.ccs_max_length} \


### PR DESCRIPTION
@Bernadetadad, can you review and then merge this pull request? 

I was looking at the PacBio rule again, and noticed that you weren't actually logging output. You had defined a log file, but not instructed `ccs` to actually log its output there. 

That is now fixed. I also re-named the log to start with the name of the rule followed by experiment rather than the other way around. This is just stylistic and makes it consistent with other rules.