### PR TITLE
update `alignparse` to 0.1.4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -391,7 +391,7 @@ dependencies:
   - zlib=1.2.11=h516909a_1009
   - zstd=1.4.5=h6597ccf_2
   - pip:
-    - alignparse==0.1.3
+    - alignparse==0.1.4
     - dill==0.3.2
     - dms-variants==0.8.5
     - dna-features-viewer==3.0.3


### PR DESCRIPTION
@Bernadetadad, this updates `alignparse` so it now handles the new `ccs` summaries (see #84).

Can you review and merge this? As soon as that is done, you should be able to parse the new CCS reports. (Note that after you merge this into `main` you will also have to merge `main` into your local branch).  