### PR TITLE
use `alignparse 0.1.6

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -393,7 +393,7 @@ dependencies:
   - zlib=1.2.11=h516909a_1009
   - zstd=1.4.5=h6597ccf_2
   - pip:
-    - alignparse==0.1.5
+    - alignparse==0.1.6
     - dill==0.3.2
     - dms-variants==0.8.5
     - dna-features-viewer==3.0.3


### PR DESCRIPTION
@Bernadetadad, this updates to `alignparse` with the fixed `minimap2` options (no `--for-only`). Can you review and merge? 