### PR TITLE
Edit distance

### DIFF
--- a/notebooks/process_viral_barcode_replicates.py.ipynb
+++ b/notebooks/process_viral_barcode_replicates.py.ipynb
@@ -23,6 +23,7 @@
    "source": [
     "import gzip\n",
     "import itertools\n",
+    "import random\n",
     "\n",
     "from IPython.display import display\n",
     "\n",


### PR DESCRIPTION
This pull request plots the distribution of the edit distance between pairs viral barcodes. It only samples the first (alphabetical) one thousand unique barcodes in each viral barcode set, grouped by `(experiment, source, gene, and tag)`. I have tried to run the comparison on all viral barcodes, but the computation is too slow. The notebook times out before it can complete.

I think this sample still gives a sense of the distribution. Most viral barcodes are 8-12 nt different from one another.
![edit_distance_trial1](https://user-images.githubusercontent.com/19295310/98405337-b493bf00-2031-11eb-8d1a-55f5c6dc42a6.png)
![edit_distance_trial2](https://user-images.githubusercontent.com/19295310/98405343-b6f61900-2031-11eb-84ff-d8be22f92250.png)

If you dig into the dataframe, you can see that there are some barcodes that are 1-2 nt different from one another. These likely represent errors generated during viral replication or sequencing library prep that can be corrected with UMI tools.
