### PR TITLE
Changed plots from SVG to PDF

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -67,7 +67,7 @@ rule all:
                     "{expt}_viral_bc_fates.svg"),
                expt=expts.expts_with_progeny_barcodes),
         expand(join(config['viral_progeny_dir'],
-                    "{expt}_viral_bc_replicates.svg"),
+                    "{expt}_viral_bc_replicates.pdf"),
                expt=expts.expts_with_progeny_barcodes),
         expand(join(config['pacbio_dir'], "{expt}_ccs_summaries.svg"),
                expt=expts.expts_with_pacbio),

--- a/rules/viral_progeny.smk
+++ b/rules/viral_progeny.smk
@@ -10,7 +10,7 @@ rule process_viral_barcode_replicates:
                                           "{expt}_"
                                           "viral_bc_in_progeny_freq.csv.gz"),
         plot=report(join(config['viral_progeny_dir'],
-                         "{expt}_viral_bc_replicates.svg"),
+                         "{expt}_viral_bc_replicates.pdf"),
                     caption='../report/viral_bc_replicates.rst',
                     category="{expt}")
     log:


### PR DESCRIPTION
This pull request simply changes the progeny viral barcode replicate plots from SVG to PDF. The PDF files are much smaller and are incorporated into the report.

This pull request closes issue #101 .