### PR TITLE
update to `alignparse` 0.2.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -395,7 +395,7 @@ dependencies:
   - zlib=1.2.11=h516909a_1009
   - zstd=1.4.5=h6597ccf_2
   - pip:
-    - alignparse==0.2.2
+    - alignparse==0.2.3
     - dill==0.3.2
     - dms-variants==0.8.5
     - dna-features-viewer==3.0.3


### PR DESCRIPTION
@Bernadetadad, just upgrades `alignparse` to handle negative site numbers when building consensus if you can review and merge. 