### PR TITLE
Function for merging deletion ranges

### DIFF
--- a/notebooks/merge_consecutive_deletions.ipynb
+++ b/notebooks/merge_consecutive_deletions.ipynb
@@ -1,0 +1,120 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This function merges consecutive deletions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def merge_dels(s):\n",
+    "    \"\"\"Merge consecutive deletions\"\"\"\n",
+    "    import alignparse.consensus\n",
+    "    import re\n",
+    "\n",
+    "    # parse mutations\n",
+    "    df = alignparse.consensus.process_mut_str(s)\n",
+    "\n",
+    "    # extract position and from:to deletion list\n",
+    "    mut_list = []\n",
+    "    for i in df[1]:\n",
+    "        mut = i.split()\n",
+    "        mut_pair = re.findall(r'\\d+', str(mut))\n",
+    "        for i in range(0, len(mut_pair)):\n",
+    "            mut_pair[i] = int(mut_pair[i])\n",
+    "        mut_list.append(mut_pair)\n",
+    "    mut_list\n",
+    "\n",
+    "    # merge consecutive ranges\n",
+    "    mut_list.sort(key=lambda interval: interval[0])\n",
+    "    merged = [mut_list[0]]\n",
+    "    merged_2 = []\n",
+    "    for current in mut_list:\n",
+    "        previous = merged[-1]\n",
+    "        if current[0] == previous[1]+1:\n",
+    "            previous[1] = max(previous[1], current[1])\n",
+    "        else:\n",
+    "            merged_2.append(current)\n",
+    "    merged_2\n",
+    "\n",
+    "    # remove duplications from above loop\n",
+    "    new_range = []\n",
+    "    for elem1 in merged_2:\n",
+    "        for _elem2 in elem1:\n",
+    "            if elem1 not in new_range:\n",
+    "                new_range.append(elem1)\n",
+    "    new_range\n",
+    "\n",
+    "    # create range-corrected (RC) deletion list\n",
+    "    deletion_RC = []\n",
+    "    for elem1 in new_range:\n",
+    "        range_str = [str(x) for x in elem1]\n",
+    "        mut = ['del' + range_str[0] + 'to' + range_str[1]]\n",
+    "        mut = ''.join(mut)\n",
+    "        deletion_RC.append(mut)\n",
+    "\n",
+    "    # overwrite mutation tuple with new range\n",
+    "    x = df\n",
+    "    y = list(df)\n",
+    "    y[1] = deletion_RC\n",
+    "    x = tuple(y)\n",
+    "    print(sum(x, []))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['G885T', 'del1474to2187']\n",
+      "['G885T', 'del1474to2150', 'del2152to2187']\n",
+      "['G85T', 'G885T', 'del1390to1909', 'del1920to1930']\n"
+     ]
+    }
+   ],
+   "source": [
+    "merge_dels('G885T del1474to2151 del2152to2187')\n",
+    "merge_dels('G885T del1474to2150 del2152to2187')\n",
+    "merge_dels('del1390to1701 del1702to1909 del1920to1930 G885T G85T')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
@jbloom, as per our discussion, I've written a `merge_dels` function in [`merge_consecutive_deletions.ipynb`](https://github.com/jbloomlab/barcoded_flu_pdmH1N1/blob/merge_consecutive_indels/notebooks/merge_consecutive_deletions.ipynb). This only deals with deletions not insertions, but I've looked at the insertion strings and have not seen this range issue happening for insertions (I can still write something for insertions too, if you think I should, it needs to be slightly different because of input string differences). 

There's a check at the bottom of the notebook, it seems to work as it should.

Let me know if this works or if I should change something. 