### PR TITLE
Changed limit percentile for viralbarcode to 0.99

### DIFF
--- a/notebooks/viral_bc_background_freq.py.ipynb
+++ b/notebooks/viral_bc_background_freq.py.ipynb
@@ -550,7 +550,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Calculate cutoff limit percentile for each gene's distribution in uninfected cells and plot. For now hardcoded to 95th percentile:"
+    "Calculate cutoff limit percentile for each gene's distribution in uninfected cells and plot. For now hardcoded to 99th percentile:"
    ]
   },
   {
@@ -559,7 +559,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "limit_percentile = 0.95\n",
+    "limit_percentile = 0.99\n",
     "\n",
     "uninfected_frac_limit = {}\n",
     "for gene in barcoded_viral_genes:\n",


### PR DESCRIPTION
This pull request changes the (arbitrarily determined) limit for viral barcode filtering from the 95th percentile seen in uninfected cells to 99th percentile seen in uninfected.

Please merge.