### PR TITLE
Revised bc rank in cell

### DIFF
--- a/scProgenyProduction_analysis.py.ipynb
+++ b/scProgenyProduction_analysis.py.ipynb
@@ -902,6 +902,266 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Set viral barcode freqs missing in progeny data to 0. If a viral barcode is seen in the cell but not in the progeny data, this is meaningful."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>cell_barcode</th>\n",
+       "      <th>infected</th>\n",
+       "      <th>infecting_viral_tag</th>\n",
+       "      <th>gene</th>\n",
+       "      <th>frac_viral_UMIs</th>\n",
+       "      <th>viral_barcode</th>\n",
+       "      <th>viral_bc_UMIs</th>\n",
+       "      <th>frac_viral_bc_UMIs</th>\n",
+       "      <th>reject_uninfected</th>\n",
+       "      <th>sup_count</th>\n",
+       "      <th>freq_progeny</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AAACCCAGTAACAAGT</td>\n",
+       "      <td>False</td>\n",
+       "      <td>none</td>\n",
+       "      <td>fluHA</td>\n",
+       "      <td>0.000048</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AAACCCATCATTGCTT</td>\n",
+       "      <td>False</td>\n",
+       "      <td>none</td>\n",
+       "      <td>fluHA</td>\n",
+       "      <td>0.000051</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>AAACGAAAGATGTTGA</td>\n",
+       "      <td>False</td>\n",
+       "      <td>none</td>\n",
+       "      <td>fluHA</td>\n",
+       "      <td>0.000204</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>AAACGCTCAAATGATG</td>\n",
+       "      <td>False</td>\n",
+       "      <td>none</td>\n",
+       "      <td>fluHA</td>\n",
+       "      <td>0.000107</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>AAACGCTCATGGACAG</td>\n",
+       "      <td>False</td>\n",
+       "      <td>none</td>\n",
+       "      <td>fluHA</td>\n",
+       "      <td>0.000119</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>66332</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>wt</td>\n",
+       "      <td>fluNA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>TTTTTCCCTTACATAT</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>4.799773e-07</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>66333</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>wt</td>\n",
+       "      <td>fluNA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>TTTTTCTTACGATCAC</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>4.799773e-07</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>66334</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>wt</td>\n",
+       "      <td>fluNA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>TTTTTCTTCGAGATAG</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>4.799773e-06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>66335</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>wt</td>\n",
+       "      <td>fluNA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>TTTTTGGGATCATTGC</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>9.599545e-07</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>66336</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>wt</td>\n",
+       "      <td>fluNA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>TTTTTTTACTCAGAAT</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>9.599545e-07</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>66337 rows × 11 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           cell_barcode infected infecting_viral_tag   gene  frac_viral_UMIs  \\\n",
+       "0      AAACCCAGTAACAAGT    False                none  fluHA         0.000048   \n",
+       "1      AAACCCATCATTGCTT    False                none  fluHA         0.000051   \n",
+       "2      AAACGAAAGATGTTGA    False                none  fluHA         0.000204   \n",
+       "3      AAACGCTCAAATGATG    False                none  fluHA         0.000107   \n",
+       "4      AAACGCTCATGGACAG    False                none  fluHA         0.000119   \n",
+       "...                 ...      ...                 ...    ...              ...   \n",
+       "66332               NaN      NaN                  wt  fluNA              NaN   \n",
+       "66333               NaN      NaN                  wt  fluNA              NaN   \n",
+       "66334               NaN      NaN                  wt  fluNA              NaN   \n",
+       "66335               NaN      NaN                  wt  fluNA              NaN   \n",
+       "66336               NaN      NaN                  wt  fluNA              NaN   \n",
+       "\n",
+       "          viral_barcode  viral_bc_UMIs  frac_viral_bc_UMIs reject_uninfected  \\\n",
+       "0                   NaN            0.0                 0.0             False   \n",
+       "1                   NaN            0.0                 0.0             False   \n",
+       "2                   NaN            0.0                 0.0             False   \n",
+       "3                   NaN            0.0                 0.0             False   \n",
+       "4                   NaN            0.0                 0.0             False   \n",
+       "...                 ...            ...                 ...               ...   \n",
+       "66332  TTTTTCCCTTACATAT            NaN                 NaN               NaN   \n",
+       "66333  TTTTTCTTACGATCAC            NaN                 NaN               NaN   \n",
+       "66334  TTTTTCTTCGAGATAG            NaN                 NaN               NaN   \n",
+       "66335  TTTTTGGGATCATTGC            NaN                 NaN               NaN   \n",
+       "66336  TTTTTTTACTCAGAAT            NaN                 NaN               NaN   \n",
+       "\n",
+       "       sup_count  freq_progeny  \n",
+       "0            NaN  0.000000e+00  \n",
+       "1            NaN  0.000000e+00  \n",
+       "2            NaN  0.000000e+00  \n",
+       "3            NaN  0.000000e+00  \n",
+       "4            NaN  0.000000e+00  \n",
+       "...          ...           ...  \n",
+       "66332        1.0  4.799773e-07  \n",
+       "66333        1.0  4.799773e-07  \n",
+       "66334       10.0  4.799773e-06  \n",
+       "66335        2.0  9.599545e-07  \n",
+       "66336        2.0  9.599545e-07  \n",
+       "\n",
+       "[66337 rows x 11 columns]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "viral_bc_freqs['freq_progeny'] = viral_bc_freqs['freq_progeny'].fillna(0)\n",
+    "\n",
+    "viral_bc_freqs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Annotated raw plots\n",
     "**I am not doing any filtering on this data yet. I will plot the data in its raw form first.**"
    ]
@@ -923,7 +1183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -948,7 +1208,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776402599012)>"
+       "<ggplot: (8783974229050)>"
       ]
      },
      "metadata": {},
@@ -981,7 +1241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -1006,7 +1266,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776403858517)>"
+       "<ggplot: (8783974286062)>"
       ]
      },
      "metadata": {},
@@ -1040,12 +1300,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/fh/fast/bloom_j/software/miniconda3/envs/barcoded_flu_pdmH1N1/lib/python3.8/site-packages/pandas/core/series.py:726: RuntimeWarning: divide by zero encountered in log10\n",
+      "/fh/fast/bloom_j/software/miniconda3/envs/barcoded_flu_pdmH1N1/lib/python3.8/site-packages/plotnine/layer.py:372: PlotnineWarning: stat_bin : Removed 8755 rows containing non-finite values.\n"
+     ]
+    },
+    {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiYAAAFOCAYAAACygdbsAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA/s0lEQVR4nO3deViU5f4/8Pcg2zCgKQw4IgxqouB60EwwFbU0SSuPR0olNdfULE1t8WQu5dEs01JS61tooYZlecxcSJRUNFMUKwU1BLTCBJNjbArM5/cHP54cZkA25UHer+vi0rmf7fPcMze8eTY0IiIgIiIiUgGb2i6AiIiIqASDCREREakGgwkRERGpBoMJERERqQaDCREREakGgwkRERGpBoMJERERqQaDCREREakGgwkRERGpBoMJ1bohQ4ZAq9UiKyurzHlGjhwJOzs7/PHHH1i3bh00Gg1SU1NrtI758+dDo9Hccr4xY8bA2dm5Rrdd2zQaDebPn1/bZdAdlpqaCo1Gg3Xr1t22bfznP//B1q1bLdpjY2Oh0WgQGxt727ZNdRODCdW6cePGIT8/Hxs3brQ6/X//+x+++uorDBo0CB4eHnjkkUdw+PBhGAyGO1wpEVVWWcEkICAAhw8fRkBAwJ0vilSNwYRq3cCBA9GsWTN8/PHHVqdv2rQJeXl5GDduHABAr9eje/fucHBwKHe9ubm5NV7rnVTX66+qvLw88E943Vpd/3w0bNgQ3bt3R8OGDWu7FFIZBhOqdQ0aNMDo0aMRHx+Pn376yWJ6REQEDAYDBg4cCABWT+UEBwejffv22L9/P4KCguDk5ISxY8cCAKKiotC/f38YDAZotVr4+fnh5ZdfRk5OTrXqPnXqFPr16wedTge9Xo9nn33W4odFeHg4evXqBXd3d+h0OnTo0AFLly5FQUGB2Xzl1Z+VlYWZM2eiZcuWcHBwgLu7O0JCQpCUlKQs/+eff2LKlCnw9PSEvb09WrZsiX//+9+4fv262XauXbuGCRMmwNXVFc7Oznj44Ydx9uxZq/t37tw5jBgxAu7u7nBwcICfnx/Cw8Mr1DcajQbPPvss1q5dC19fXzg4OMDf3x+fffaZ2Xwl72V0dDTGjh0LvV4PJycnXL9+HSaTCUuXLkXbtm2V/R41ahR+/fVXs3WICP7zn//AaDTC0dERXbt2xbfffovg4GAEBwdb7P+sWbPQokUL2Nvbw9PTE9OnT7f4LJTU/+mnn8LPzw9OTk7o1KkTtm/frsxz4MABaDQabNq0yWL/P/nkE2g0Ghw9erTMPirZ92+//RZPP/00mjRpAp1Oh8GDB+P8+fNm85b3+bhw4QLCwsLM3qdly5bBZDKZreP3339HaGgoXFxc0KhRIzzxxBO4dOmSRV3W+g0oPoXp4+Nj1nb9+nUsXLgQfn5+cHR0hKurK/r06YNDhw4p/ZiTk4P169dDo9FAo9Eo6y7rVM62bdsQGBgIJycnuLi44KGHHsLhw4fN5ik57Xrq1CkMHz4cjRo1goeHB8aOHYv//e9/ZfY51RFCpALnzp0TjUYj06dPN2s/deqUAJCXX35ZaYuIiBAAkpKSorT17t1bmjRpIl5eXrJy5UrZt2+ffPfddyIi8vrrr8vy5cvlm2++kdjYWFmzZo20aNFC+vTpY7atefPmSUWGxOjRo8Xe3l68vb1l0aJFEh0dLfPnzxdbW1sZNGiQ2bwzZsyQ1atXy65du2Tv3r2yfPlycXNzk6efftpsvrLqv3btmrRr1050Op0sXLhQdu/eLVu2bJHnn39e9u7dKyIieXl50rFjR9HpdPL2229LdHS0zJ07V2xtbSUkJETZhslkkj59+oiDg4NS97x586Rly5YCQObNm2fW740aNZIOHTrIJ598ItHR0TJz5kyxsbGR+fPn37KPAIiXl5f4+/vLpk2bZNu2bfLwww8LAPn888+V+UreS09PT5k4caLs3LlTvvjiCyksLJSJEycKAHn22Wdl165dsmbNGtHr9eLl5SUZGRnKOl555RUBIBMnTpRdu3bJhx9+KN7e3mIwGKR3797KfDk5OdK5c2dxc3OTd955R/bs2SPvvvuuNGrUSPr27Ssmk8msfh8fH+nWrZts3rxZduzYIcHBwWJrayvJycnKfP/4xz+kR48eFvt/3333yX333VduH5Xsu5eXl4wdO1Z27twpH3zwgbi7u4uXl5dcvXpVmbesz8fly5fF09NT9Hq9rFmzRnbt2iXPPvusAJDJkycry+fm5oqfn580atRIVq5cKbt375bnnntOvL29BYBERESYbevmfisxevRoMRqNyuuCggLp06eP2NrayqxZs2THjh2ybds2mTNnjmzatElERA4fPixarVZCQkLk8OHDcvjwYTl16pSIiOzbt08AyL59+5R1btiwQQBI//79ZevWrRIVFSVdunQRe3t7OXDggDJfyVht06aNvPbaa/Ltt9/KO++8Iw4ODhZji+oeBhNSjd69e4ubm5vcuHFDaZs5c6YAkLNnzyptZQUTABITE1PuNkwmkxQUFMh3330nAOTkyZPKtMoEEwDy7rvvmrUvWrRIAMjBgwetLldUVCQFBQXyySefSIMGDeTPP/+8Zf0LFy4UAPLtt9+WWc+aNWsEgGzevNms/c033xQAEh0dLSIiO3fuLLfum4PJgAEDpHnz5vK///3PbN5nn31WHB0dzWq3BoBotVq5dOmS0lZYWCht27aVe++9V2kreS9HjRpltnxiYqIAkClTppi1HzlyRADInDlzRETkzz//FAcHB3niiSfM5jt8+LAAMPsBu3jxYrGxsZGjR4+azfvFF18IANmxY4dZ/R4eHnLt2jWl7dKlS2JjYyOLFy+2qP/EiRNK2w8//CAAZP369eX2UcmyQ4YMMWuPi4sTAPLGG28obWV9Pl5++WUBIEeOHDFrnzx5smg0Gjlz5oyIiKxevVoAyH//+1+z+SZMmFDlYPLJJ58IAPnwww/L3U+dTiejR4+2aC8dTIqKiqRZs2bSoUMHKSoqUub766+/xN3dXYKCgpS2krG6dOlSs3VOmTJFHB0dzUIm1T08lUOqMW7cOGRmZmLbtm0AgMLCQkRGRqJnz55o3br1LZdv3Lgx+vbta9F+/vx5jBgxAk2bNkWDBg1gZ2eH3r17AwASExOrXO/IkSPNXo8YMQIAsG/fPqXtxIkTePTRR+Hq6qpse9SoUSgqKrI4hWKt/p07d8LX1xcPPvhgmXXs3bsXOp0O//rXv8zax4wZAwCIiYkxq6usukvk5+cjJiYGQ4YMgZOTEwoLC5WvkJAQ5Ofn4/vvvy+znhL9+vWDh4eH8rpBgwZ44okn8Msvv1icjhk6dKjZ65JaS/ahRLdu3eDn56fs0/fff4/r168jNDTUbL7u3btbnHbYvn072rdvj86dO5vt04ABA6yeUujTpw9cXFyU1x4eHnB3d0daWprSNnz4cLi7u5ud4lq5ciX0ej2eeOKJcnrnb6Xfj6CgIBiNRrPPEWD987F37174+/ujW7duZu1jxoyBiGDv3r0AivvTxcUFjz76qNl8pd/7yti5cyccHR2VU0rVdebMGfz+++946qmnYGPz948mZ2dnDB06FN9//73FqdLS+9OxY0fk5+fj8uXLNVIT1Q4GE1KNf/3rX2jUqBEiIiIAADt27MAff/yhXPR6K9bu0snOzkbPnj1x5MgRvPHGG4iNjcXRo0fx5ZdfAii+0LIqbG1t4erqatbWtGlTAMCVK1cAFJ/779mzJ3777Te8++67OHDgAI4ePar8ECu9bWv1Z2RkoHnz5uXWcuXKFTRt2tTiVmd3d3fY2toq9Vy5cqXcum9eX2FhIVauXAk7Ozuzr5CQEABAZmZmuTVZW+/NbSU1lSi97yXTrfVJs2bNzPYJgFkAKlG67Y8//sCPP/5osU8uLi4QEYt9Kt1PAODg4GD2vjk4OGDSpEnYuHEjsrKykJGRgc2bN2P8+PG3vDi7RFn9dKs+Aor3v6w+Kple8q+1PrK27YrKyMhAs2bNzEJEddzqPTeZTLh69apZe+n3qKTPqzquSR1sa7sAohJarRbDhw/Hhx9+iPT0dHz88cdwcXHBsGHDKrS8tWeQ7N27F7///jtiY2OVoyQAyn1mSkUUFhbiypUrZt8YSy4kLGnbunUrcnJy8OWXX8JoNCrzJSQkVLh+vV5vcXShNFdXVxw5cgQiYraOy5cvo7CwEG5ubsp85dVdonHjxmjQoAGeeuopTJ061eo2W7RoUW5N1tZ7c1vpHyil971kenp6ukUw+/333832CSgOHda2dfNREzc3N2i12jLv/ipZZ2VNnjwZS5Yswccff4z8/HwUFhbimWeeqfDyZfXTvffea9Zm7fPh6uqK9PR0i/bff/8dAMz66YcffqjQth0dHa1eQFo6uOn1ehw8eBAmk6lGwsnN73lpv//+O2xsbNC4ceNqb4fUj0dMSFXGjRuHoqIivPXWW9ixYweefPJJODk5VXl9Jd/MS//2unbt2mrVCQAbNmwwe13yHJaSuw6sbVtE8OGHH1Z4GwMHDsTZs2eVQ/LW9OvXD9nZ2RbPivjkk0+U6UDxqYny6i7h5OSEPn364MSJE+jYsSO6du1q8WXtaEJpMTExZoGhqKgIUVFRaNWq1S2PApWcsoiMjDRrP3r0KBITE5V9uv/+++Hg4ICoqCiz+b7//nuzUy4AMGjQICQnJ8PV1dXqPpU+9VNRBoMBw4YNw/vvv481a9Zg8ODB8Pb2rvDypd+PQ4cOIS0tzeqdMaX169cPp0+fxvHjx83aS+4KKnnP+/Tpg7/++ks5TVrC2rODfHx8cPbsWbM7uq5cuaLcaVNi4MCByM/Pv+XD2UofZSpLmzZt4OnpiY0bN5rdLp6Tk4MtW7Yod+rQ3Y9HTEhVunbtio4dO2LFihUQkQqfxilLUFAQGjdujGeeeQbz5s2DnZ0dNmzYgJMnT1Zrvfb29li2bBmys7Nx33334dChQ3jjjTcwcOBAPPDAAwCAhx56CPb29hg+fDhefPFF5OfnY/Xq1RaHo8szffp0REVF4bHHHsPLL7+Mbt26IS8vD9999x0GDRqEPn36YNSoUQgPD8fo0aORmpqKDh064ODBg/jPf/6DkJAQ5fqU/v37o1evXnjxxReRk5ODrl27Ii4uDp9++qnFdt9991088MAD6NmzJyZPngwfHx/89ddf+OWXX/D111+XG5RKuLm5oW/fvpg7dy50Oh3ef/99JCUlWdwybE2bNm0wceJErFy5EjY2Nhg4cCBSU1Mxd+5ceHl5YcaMGQCAJk2a4IUXXsDixYvRuHFjDBkyBL/++isWLFgAg8Fg9pv89OnTsWXLFvTq1QszZsxAx44dYTKZcOHCBURHR2PmzJm4//77K/rWmHn++eeVZUtORVbUsWPHMH78eAwbNgwXL17Ev//9b3h6emLKlCm3XHbGjBn45JNP8Mgjj2DhwoUwGo345ptv8P7772Py5Mnw9fUFAIwaNQrLly/HqFGjsGjRIrRu3Ro7duzA7t27Ldb51FNPYe3atQgLC8OECRNw5coVLF261OJ5I8OHD0dERASeeeYZnDlzBn369IHJZMKRI0fg5+eHJ598EgDQoUMHxMbG4uuvv4bBYICLiwvatGljsV0bGxssXboUI0eOxKBBgzBp0iRcv34db731FrKysrBkyZJK9SvVYbV55S2RNe+++64AEH9/f6vTy7orp127dlbnP3TokAQGBoqTk5Po9XoZP368HD9+3OJuhMrclaPT6eTHH3+U4OBg0Wq10qRJE5k8ebJkZ2ebzfv1119Lp06dxNHRUTw9PWX27NnK3TE33yZZXv1Xr16V559/Xry9vcXOzk7c3d3lkUcekaSkJGWeK1euyDPPPCMGg0FsbW3FaDTKK6+8Ivn5+WbrysrKkrFjx8o999wjTk5O8tBDD0lSUpLFXTkiIikpKTJ27Fjx9PQUOzs70ev1EhQUZHa3SFkAyNSpU+X999+XVq1aiZ2dnbRt21Y2bNhgNl/Je1n6ThmR4rs03nzzTfH19RU7Oztxc3OTsLAwuXjxotl8JpNJ3njjDWnevLnY29tLx44dZfv27dKpUyeLO16ys7Pl1VdflTZt2oi9vb1yS/SMGTPM7iAqqb80o9Fo9Q4TEREfHx/x8/O7Zd+U3vfo6Gh56qmn5J577lFurT137pzZvOV9PtLS0mTEiBHi6uoqdnZ20qZNG3nrrbfM7mwREfn1119l6NCh4uzsLC4uLjJ06FA5dOiQxTgQEVm/fr34+fmJo6Oj+Pv7S1RUlMVdOSLFt6q/9tpr0rp1a7G3txdXV1fp27evHDp0SJknISFBevToIU5OTmZ3Slm7XVhEZOvWrXL//feLo6Oj6HQ66devn8TFxZnNUzJWb75t/OY+vfl7A9U9GhE+YpGIapZGo8HUqVOxatWqWtl+SkoK2rZti3nz5mHOnDm3fXs//vgjOnXqhPDw8Aod6QCKH7D29NNP4+jRo+jatettrpCo7uCpHCKq006ePIlNmzYhKCgIDRs2xJkzZ5RTD9U9FXgrycnJSEtLw5w5c2AwGCxubyaiymMwIaI6TafT4dixY/joo4+QlZWFRo0aITg4GIsWLbJ6i2xNev3115XH1n/++ee8OJOoBvBUDhEREakGbxcmIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLV4HNMKunChQsV+pPvRHRnuLm5lflH8zheidSlvPFagsGkEi5cuAA/Pz/k5ubWdilE9P85OTkhMTHR4psdxyuR+pQ1Xm/GYFIJmZmZyM3NRWRkJPz8/Gq7HKJ6LzExEWFhYcjMzLT4RsfxSqQu5Y3XmzGYVIGfnx8CAgJquwwiqgCOV6K6hRe/EhERkWowmBAREZFq8FQO1VlXrlzBpEmT8NNPP2Hw4MHIycnB6tWra7ssIrKC45UqikdMqM769NNPodPpkJSUBIPBUOHlDh06hM6dO1u0T548GcuWLTNrKygoQIcOHRASElLdconqteqMV09PT8yYMcOsneP17sVgQnXWxYsX0aZNG2g0mtu2jT179qCwsBA//fQTkpKSbtt2iO521RmvWq0W27dvx7lz58qdj+P17sBgQnXStGnT8MUXX+CDDz5A69atsWPHDmWatSMigwYNQlRUVKW3ExUVhSFDhiAwMLBKyxNR9cers7MzwsLC8Oabb5a7HY7XuwODCdVJK1euxJAhQzBx4kScO3futhy6zcjIwL59+zBkyBAMHToUX375JQoKCmp8O0R3u5oYr9OmTcPBgwdx4sQJq9M5Xu8eDCZUL2VmZsLPz8/sa+fOnWbzbNmyBZ6enrjvvvvwyCOPIDs7G3v37q2lionqtyZNmmDSpElYvHix1ekcr3cPBhOql9zc3JCYmGj2NXDgQLN5Nm/ejCFDhgAoPpQ8YMAAHh4mqkUTJ05EUlIS9u/fbzGN4/XuwduF6a6j0+mQl5dn1paRkVGpdZw4cQJnzpzBpUuXsGHDBgBAXl4e8vPzkZmZCTc3txqrl6g+q8x41el0eO6557BkyRIYjUalneP17sIjJnTXadmyJYqKirBjxw4UFhZi3bp1uHTpUqXWERUVhe7duyM2NhbR0dGIjo7G/v370bRpU2zZsuU2VU5U/1R2vI4aNQpXrlzBgQMHlDaO17sLgwnddVxcXLBkyRLMnTsXnTp1wuXLl9GhQ4cKL5+fn49t27ZhzJgxcHd3V748PDwwatQobN68+TZWT1S/VHa82tvb44UXXsDVq1cBcLzejTQiIrVdRF1x/PhxdOnSBfHx8fyjYEQqUN6Y5HglUpeKjkkeMSEiIiLVYDAhIiIi1WAwISIiItXg7cKVUHJLW0JCQu0WQkQAgMTExDKncbwSqUt54/VmDCaVkJWVBQAYN25c7RZCRAonJyerz6ngeCVSn7LG680YTCqh5E91R0ZGws/Pr5arISKg+Cm+3t7eFu0cr0TqU9Z4vRmDSRX4+fnx9kOiOoLjlahu4cWvREREpBoMJkRERKQaDCZERESkGgwmREREpBoMJkRERKQaDCZERESkGgwmREREpBoMJkRERKQafMAaWRgxYoRF28aNG2uhEiIiqm94xISIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUw7Y2N759+3bs3bsXqampCAwMxOzZs5Vp48ePR1ZWFmxsirOTXq9HeHi4Mj0uLg7r1q1DVlYW/Pz88Pzzz8PV1VWZHhkZiZ07d8JkMqFnz56YOHEibG2Ldzc7Oxvh4eE4fvw4tFotQkNDERIScof2moiIiMpSq8GkSZMmCA0NRUJCAv766y+L6a+88gq6dOli0f7rr7/ivffewyuvvAI/Pz9ERETg7bffxuLFiwEA0dHR2L9/P9555x04Ojri9ddfx+bNmzFixAgAwNq1a1FUVISIiAikp6fjtddeQ/PmzdGxY8fbu8NERERUrlo9lRMUFITu3bujYcOGlVpu3759CAgIQOfOneHg4ICRI0ciKSkJ6enpAIA9e/bg8ccfh4eHBxo1aoTQ0FDs2bMHAJCfn4+4uDiEhYXByckJrVq1Qt++fZXpREREVHtq9YjJraxYsQIiAm9vb4SFhcHf3x8AkJaWBl9fX2U+FxcX6PV6pKWlwWAw4MKFC/Dx8VGmt2jRApmZmcjJycGlS5cAAN7e3sr0li1bYuvWrVZrSE9PVwJPYmJiDe8hERER3Uy1weSFF15Aq1atAAAxMTFYsGABVq5cCXd3d+Tn58PJyclsfp1Oh7y8PADFR0V0Op3ZNADIy8tDfn4+tFptmcuWtnbtWixYsKDG9ouIiIjKptq7cvz9/eHg4AAHBweEhISgZcuWiI+PBwA4OjoiNzfXbP6cnBwlcJSeXvJ/rVYLR0dHixBy87KlTZo0CfHx8YiPj0dkZGSN7R8RERFZUu0Rk9JsbGwgIgAAo9GI1NRUZVp2djYyMzNhNBoBFJ+mSUlJgZ+fHwAgJSUFbm5u0Ol08PT0BABcvHgRXl5eyvSSZUszGAwwGAy3a7eIiIjoJrV6xKSoqAg3btyAyWSCyWTCjRs3UFhYiIyMDJw6dQoFBQUoKCjA7t27ce7cOfzjH/8AAAQHByM+Ph4nT57E9evXsWHDBrRp00YJEP369cO2bdtw+fJlXLt2DVFRUXjwwQcBFB9N6dGjBzZs2IDc3FykpKQgJiYG/fr1q7V+ICIiomK1esQkKioKn332mfI6Li4Offv2xT//+U988MEHSE9Ph62tLby8vDB37lwleHh5eWHatGlYtWoVrl69Cn9/f8yaNUtZT//+/ZGRkYEZM2agqKgIvXr1QmhoqDJ90qRJWLVqFcaMGQMnJyeMHDkSnTp1unM7TkRERFZppOT8CN3S8ePH0aVLF8THxyMgIKC2y7ltSp73crONGzfWQiVEVVdfxivR3Ua1F78SERFR/cNgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqUaVg0rdvX2RlZVm0X7t2DX379q1uTURERFRPVSmYxMbG4saNGxbt+fn5OHDgQLWLIiIiovrJtjIz//jjj8r/T58+jUuXLimvi4qKsGvXLnh6etZcdURERFSvVCqYdO7cGRqNBhqNxuopG61Wi5UrV1Z4fdu3b8fevXuRmpqKwMBAzJ49W5mWlpaGlStXIjU1FU2bNsXkyZPRrl07ZXpcXBzWrVuHrKws+Pn54fnnn4erq6syPTIyEjt37oTJZELPnj0xceJE2NoW7252djbCw8Nx/PhxaLVahIaGIiQkpDJdQURERLdBpU7lpKSkIDk5GSKCH374ASkpKcrXb7/9hmvXrmHs2LEVXl+TJk0QGhqK/v37m7UXFhbijTfeQGBgIDZt2oShQ4di0aJFyM7OBgD8+uuveO+99zB16lRERkaiWbNmePvtt5Xlo6OjsX//frzzzjtYs2YNzp8/j82bNyvT165di6KiIkRERGDu3LnYsGGD2dEgIiIiqh2VCiZGoxE+Pj4wmUzo2rUrjEaj8mUwGNCgQYNKbTwoKAjdu3dHw4YNzdp/+uknXL9+HUOGDIGdnR369OkDDw8PHDp0CACwb98+BAQEoHPnznBwcMDIkSORlJSE9PR0AMCePXvw+OOPw8PDA40aNUJoaCj27NkDoPg6mLi4OISFhcHJyQmtWrVC3759lelERERUeyp1KudmZ8+eRWxsLC5fvgyTyWQ27bXXXqtWURcuXIDRaISNzd+5qUWLFrhw4QKA4tM8vr6+yjQXFxfo9XqkpaXBYDDgwoUL8PHxMVs2MzMTOTk5ynUx3t7eyvSWLVti69atVmtJT09XAk9iYmK19ouIiIjKV6Vg8uGHH2Ly5Mlwc3ND06ZNodFolGkajabawSQvLw86nc6sTafTITc3F0DxUQ8nJyeL6Xl5ecr0m5cv+X9eXh7y8/Oh1WrLXLa0tWvXYsGCBdXaHyIiIqqYKgWTN954A4sWLcJLL71U0/UAKL6ItiSElMjNzVUChaOjo8X0nJycMqeX/F+r1cLR0dEihNy8bGmTJk3Co48+CqD4iElYWFg19oyIiIjKU6XnmFy9ehXDhg2r6VoU3t7eSEtLMztFlJKSopx+MRqNSE1NVaZlZ2cjMzMTRqNRWT4lJcVsWTc3N+h0OuV25osXL5pNL1m2NIPBgICAAAQEBMDPz6/G9pGIiIgsVSmYDBs2DNHR0dXeeFFREW7cuAGTyQSTyYQbN26gsLAQHTp0gJ2dHbZu3YqCggJ89913uHTpEgIDAwEAwcHBiI+Px8mTJ3H9+nVs2LABbdq0gcFgAAD069cP27Ztw+XLl3Ht2jVERUXhwQcfBFB8NKVHjx7YsGEDcnNzkZKSgpiYGPTr16/a+0NERETVU6VTOffeey/mzp2L77//XgkRN3vuuecqtJ6oqCh89tlnyuu4uDj07dsX06dPx6uvvopVq1Zh48aN8PDwwJw5c+Di4gIA8PLywrRp07Bq1SpcvXoV/v7+mDVrlrKe/v37IyMjAzNmzEBRURF69eqF0NBQZfqkSZOwatUqjBkzBk5OThg5ciQ6depUla4gIqpVI0aMsGjbuHFjLVRCVDM0IiKVXahFixZlr1Cjwfnz56tVlFodP34cXbp0QXx8PAICAmq7nNuG3+jobsDxSlQ3VemIyc3XbxARERHVlCpdY0JERER0O1TpiMmtHjv/8ccfV6kYIiIiqt+qFEyuXr1q9rqgoAA///wzsrKyrP5xPyIiIqKKqFIw+eqrryzaTCYTpkyZgpYtW1a7KCIiIqqfauwaExsbG8yYMQPLly+vqVUSERFRPVOjF78mJyejsLCwJldJRERE9UiVTuW88MILZq9FBOnp6fjmm28wevToGimMiIiI6p8qBZMTJ06YvbaxsYFer8eyZctueccOERERUVmqFEz27dtX03UQERERVS2YlMjIyMCZM2eg0Wjg6+sLvV5fU3URERFRPVSli19zcnIwduxYGAwG9OrVCz179kSzZs0wbtw45Obm1nSNREREVE9UKZi88MIL+O677/D1118jKysLWVlZ+O9//4vvvvsOM2fOrOkaiYiIqJ6o0qmcLVu24IsvvkBwcLDSFhISAq1Wi9DQUKxevbqm6iMiIqJ6pEpHTHJzc+Hh4WHR7u7uzlM5REREVGVVCiaBgYGYN28e8vPzlba8vDwsWLAAgYGBNVYcERER1S9VOpWzYsUKDBw4EM2bN0enTp2g0WiQkJAABwcHREdH13SNREREVE9UKZh06NAB586dQ2RkJJKSkiAiePLJJzFy5EhotdqarpGIiIjqiSoFk8WLF8PDwwMTJkwwa//444+RkZGBl156qUaKIyIiovqlSteYrF27Fm3btrVob9euHdasWVPtooiIiKh+qlIwuXTpEgwGg0W7Xq9Henp6tYsiIiKi+qlKwcTLywtxcXEW7XFxcWjWrFm1iyIiIqL6qUrXmIwfPx7Tp09HQUEB+vbtCwCIiYnBiy++yCe/EhERUZVVKZi8+OKL+PPPPzFlyhTcuHEDAODo6IiXXnoJr7zySo0WSERERPVHlYKJRqPBm2++iblz5yIxMRFarRatW7eGg4NDTddHRERE9UiVgkkJZ2dn3HfffTVVCxEREdVzVbr4lYiIiOh2YDAhIiIi1WAwISIiItWo1jUmRESkPiNGjLBo27hxYy1UQlR5PGJCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKphW9sFlGfFihXYv38/bG3/LjM8PBx6vR4AkJaWhpUrVyI1NRVNmzbF5MmT0a5dO2XeuLg4rFu3DllZWfDz88Pzzz8PV1dXZXpkZCR27twJk8mEnj17YuLEiWbbIiIiojtL9UdMHnvsMWzevFn5KgklhYWFeOONNxAYGIhNmzZh6NChWLRoEbKzswEAv/76K9577z1MnToVkZGRaNasGd5++21lvdHR0di/fz/eeecdrFmzBufPn8fmzZtrZR+JiIiomOqDSVl++uknXL9+HUOGDIGdnR369OkDDw8PHDp0CACwb98+BAQEoHPnznBwcMDIkSORlJSE9PR0AMCePXvw+OOPw8PDA40aNUJoaCj27NlTm7tERERU76n+vMXu3buxe/duuLm5YfDgwXjooYcAABcuXIDRaISNzd/ZqkWLFrhw4QKA4tM8vr6+yjQXFxfo9XqkpaXBYDDgwoUL8PHxMVs2MzMTOTk50Ol0d2bn6rgRI0ZYbd+4ceMdroSIiO4Wqg4mgwcPxtixY6HT6XD69GksWbIEOp0OQUFByMvLswgQOp0Oubm5AID8/Hw4OTlZTM/Ly1Om37x8yf9Lrzc9PV05ypKYmFjzO0lEREQKVQeTVq1aKf/v0KEDHnnkEcTFxSEoKAharVYJISVyc3Oh1WoBAI6OjhbTc3Jyypxe8v+S6SXWrl2LBQsW1NxOERERUZnq1DUmGo0GIgIA8Pb2RlpaGkwmkzI9JSUF3t7eAACj0YjU1FRlWnZ2NjIzM2E0GpXlU1JSzJZ1c3OzOAozadIkxMfHIz4+HpGRkbdr14iIiAgqDyYHDx5Ebm4uTCYTTp8+jW+++Qbdu3cHUHwExc7ODlu3bkVBQQG+++47XLp0CYGBgQCA4OBgxMfH4+TJk7h+/To2bNiANm3awGAwAAD69euHbdu24fLly7h27RqioqLw4IMPWtRgMBgQEBCAgIAA+Pn53bmdJyIiqodUfSpn+/btCA8Ph8lkgpubG0aOHIlevXoBAGxtbfHqq69i1apV2LhxIzw8PDBnzhy4uLgAALy8vDBt2jSsWrUKV69ehb+/P2bNmqWsu3///sjIyMCMGTNQVFSEXr16ITQ0tMZqt3ZhKC8KJSIiKp+qg8mSJUvKne7j42P2bJLSHnjgATzwwANWp2k0GoSFhSEsLKxaNRIREVHNUfWpHCIiIqpfGEyIiIhINRhMiIiISDUYTIiIiEg1GEyIiIhINRhMiIiISDVUfbswEdGdwOcOEakHj5gQERGRajCYEBERkWowmBAREZFqMJgQERGRavDiVyKieowX/pLa8IgJERERqQaDCREREakGgwkRERGpBoMJERERqQaDCREREakGgwkRERGpBoMJERERqQafY0JEVA9Ye14JkRoxmFCN4wObiIioqngqh4iIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUw7a2CyAiInUZMWKERdvGjRtroRKqj3jEhIiIiFSDwYSIiIhUg6dyiIjolnh6p+awL8vHYEK1hoOTiIhKYzChO8JaCCEiIiqNwYRIxXhUiahu4y9llVevg0l2djbCw8Nx/PhxaLVahIaGIiQkpLbLonqqOt/AGGCoNvBzR7dDvQ4ma9euRVFRESIiIpCeno7XXnsNzZs3R8eOHWu7NKJqKyvo8AcHEalZvQ0m+fn5iIuLw4oVK+Dk5IRWrVqhb9++2LNnD4NJLeJvYLdfRY/MsN+Jal99/J5Yb4PJb7/9BgDw9vZW2lq2bImtW7fWUkVEFXOnzlnXx2+IVH08Ulc1lRnXd/svF/U2mOTn50Or1Zq16XQ65OXlmbWlp6cjPT0dAJCYmHjH6qO/8eIx9bgd70Vd/eZJlcNxfOfdqT6v6TFcb4OJo6OjRQjJycmxCCtr167FggULKr3+uvzNtqK11+V9JLpZXf4s1+Xaiaypt4+k9/T0BABcvHhRaUtJSYHRaDSbb9KkSYiPj0d8fDwiIyPvaI1ERET1Tb0NJo6OjujRowc2bNiA3NxcpKSkICYmBv369TObz2AwICAgAAEBAfDz86ulaomIiOqHensqByg+GrJq1SqMGTMGTk5OGDlyJDp16lTbZREREdVb9TqYODs74+WXX67tMoiIiOj/q7encoiIiEh9GEyIiIhINRhMiIiISDUYTIiIiEg16vXFr5VV8kA2PgGWSF3atm0LJycnszaOVyJ1sjZeb8ZgUgmpqakAgLCwsNothIjMxMfHIyAgwKyN45VInayN15tpRETuYD11WmZmJnbv3g0fHx+LR9erVWJiIsLCwhAZGVlvHxDHPrj7+8Dab2Acr3UT++Du7wMeMalBbm5uGDlyZG2XUSV+fn7lJtT6gH1Qv/qA47VuYx/U3z7gxa9ERESkGgwmdzmDwYB58+bBYDDUdim1hn3APqgr+D6xDwD2Aa8xISIiItXgERMiIiJSDQYTIiIiUg0GEyIiIlIN3i5cx2zfvh179+5FamoqAgMDMXv27Cqt59SpU1iwYIFZW35+PsaOHYvHH3+8Biq9vWqqHwBg/PjxyMrKgo1NcU7X6/UIDw+vqVJvm5rqg7y8PCxYsAAXL15EYWEhmjZtiuHDh6N79+41XHH9w/FajOOV47UyGEzqmCZNmiA0NBQJCQn466+/qryedu3aYfPmzcrrixcvYtq0aejRo0dNlHnb1VQ/lHjllVfQpUuXGqjszqmpPrCzs8OUKVPg6emJBg0aIDExEfPnz8f7778PV1fXGqy4/uF4LcbxyvFaGQwmdUxQUBAA4Pz58xYf7nPnzuGjjz5CWloaGjdujLCwMGX+W9mzZw86duwIvV5f4zXfDrerH+qSmuoDW1tbeHt7AwBEBBqNBoWFhbh8+fJd842utnC8FuN45XitDAaTu8Sff/6J+fPnY9q0abjvvvvwyy+/YMGCBfDy8oKXl1e5yxYVFSE2NhZjx469Q9XePlXthxUrVkBE4O3tjbCwMPj7+9/BqmtWVfvg5ZdfxtmzZ1FYWIhOnTrB19f3DlZdv3C8FuN45Xi1hhe/3iX27duHTp06oXv37mjQoAHatGmD7t27Iy4u7pbLHjt2DDdu3EBgYOAdqPT2qko/vPDCC/i///s/fPTRR3jggQewYMECXL58+Q5WXbOq+llYsmQJoqKiMGfOHHTp0gUNGjS4QxXXPxyvxTheOV6t4RGTu8Tly5dx5MgRDB8+XGkrKipCcHAwMjIyMHXqVKU9PDzc7BBwTEwMevfuDXt7+zta8+1QlX64+betkJAQHDhwAPHx8Rg4cOAdrb2mVOezYGdnh+7du+PVV19Fs2bN0K1btztae33B8VqM45Xj1RoGk7uEXq9Hz549MX36dKvTb75w7mZZWVk4duwY3nzzzdtY3Z1T1X64mY2NDeryA5Frog+KioqQnp5ew5VRCY7XYhyvHK/W8FROHVNUVIQbN27AZDLBZDLhxo0bKCwsRHBwMOLj4/HDDz+gqKgIBQUFOHPmDC5evFju+mJjY+Hp6YnWrVvfoT2oGTXVDxkZGTh16hQKCgpQUFCA3bt349y5c/jHP/5xh/eo8mqqD5KTk/Hjjz8qfRAdHY0zZ86gffv2d3iP7j4cr8U4XjleK4N/K6eO2bhxIz777DOztr59+2L69Ok4d+4c1q9fj5SUFACAj48Pxo0bh5YtW5a5vmnTpuHBBx/EY489dlvrrmk11Q8XLlzAsmXLkJ6eDltbW3h5eSEsLAwdOnS4I/tRHTXVB2fOnMGaNWvw+++/w8bGBp6enhg2bBjuv//+O7IfdzOO12IcrxyvlcFgQkRERKrBUzlERESkGgwmREREpBoMJkRERKQaDCZERESkGgwmREREpBoMJkRERKQaDCZERESkGgwmREREpBoMJlTniAgmTpyIJk2aQKPRICEh4Y5uPzY2FhqNBllZWXd0u9bExcWhQ4cOsLOzw+OPP17b5QAAgoODy/y7H7XBx8cHK1asqNKy8+fPR+fOnWu0HiIqH4MJ1Tm7du3CunXrsH37dqSnp9/WvxFh7YdsUFAQ0tPT0ahRo9u23Yp64YUX0LlzZ6SkpGDdunVW56nqD+bq/EC/W8yaNQsxMTG1XYaqrVu3Dvfcc89tWTeDYf3EYEJ1TnJyMgwGA4KCgtC0aVPY2lr+kewbN27ctu3b29ujadOm0Gg0t20bFZWcnIy+ffuiefPmt+2Hw+1WUFBQ2yWUydnZGa6urrVdRo0TERQWFtZ2GUTWCVEdMnr0aAGgfBmNRhER6d27t0ydOlVmzJghrq6u0qtXLxERWbZsmbRv316cnJykefPmMnnyZPnrr7/M1nnw4EHp1auXaLVaueeee6R///7y559/WmwLgKSkpMi+ffsEgFy9elVZxxdffCH+/v5ib28vRqNR3n77bbNtGI1GWbRokTz99NPi7OwsXl5esnbt2nL3NT8/X6ZNmyZ6vV4cHBykR48e8sMPP4iISEpKikVtERERFuvo3bu3xXwVqbms5TIzM+XJJ58UT09P0Wq10r59e9m4caPFNp9//vky92vevHnSqVMn+eijj6RFixai0WjEZDJJVlaWTJgwQfR6vbi4uEifPn0kISFBWe6XX36RRx99VNzd3UWn00nXrl3l22+/NVv3H3/8IYMGDRJHR0fx8fGRyMhIMRqNsnz5crPte3l5ib29vRgMBpk2bdotay0xevRoeeyxx+Stt96Spk2bSpMmTWTKlCly48aNMteRkJAgwcHB4uzsLC4uLhIQECBHjx61un4RkeXLlyuf65u3OX/+fKVvJk6cKNevX1fmMZlM8uabb0qLFi3E0dFROnbsKJ9//rkyveQzu2vXLunSpYvY2dnJ3r17pXfv3jJt2jSZPXu2NG7cWDw8PGTevHlm9ZQ3hkrWe/NXyfKffvqpdOnSRZydncXDw0OGDx8uf/zxh0VNe/bskS5duohWq5XAwEBJSkoSEZGIiIgKfcbp7sNgQnVKVlaWLFy4UJo3by7p6ely+fJlESn+Yejs7CyzZ8+WpKQkSUxMFJHib/J79+6V8+fPS0xMjLRp00YmT56srO/EiRPi4OAgkydPloSEBPn5559l5cqVkpGRIVlZWRIYGCgTJkyQ9PR0SU9Pl8LCQotgcuzYMbGxsZGFCxfKmTNnJCIiQrRardk3UaPRKE2aNJHw8HA5d+6cLF68WGxsbJQ6rXnuueekWbNmsmPHDjl16pSMHj1aGjduLFeuXJHCwkJJT0+Xhg0byooVKyQ9PV1yc3Mt1nHlyhVp3ry5LFy4UNmHitRc1nK//vqrvPXWW3LixAlJTk6W9957Txo0aCDff/+9ss2KBBOdTicDBgyQ48ePy8mTJ8VkMkmPHj1k8ODBcvToUTl79qzMnDlTXF1d5cqVKyJS/AN+zZo18uOPP8rZs2fl3//+tzg6OkpaWpqy7oEDB0r79u3l0KFDcuzYMQkKChKtVqsEk88//1waNmwoO3bskLS0NDly5Ih88MEH5dZaOpg0bNhQnnnmGUlMTJSvv/5anJycyl1Hu3btJCwsTBITE+Xs2bOyefNmJXBVNJg4OzvLE088IT///LNs375d9Hq9zJkzR5lnzpw50rZtW9m1a5ckJydLRESEODg4SGxsrIj8HQI6duwo0dHR8ssvv0hmZqb07t1bGjZsKPPnz5ezZ8/K+vXrRaPRSHR0tFk9ZY2h69evy4oVK6Rhw4bK56QktHz00UeyY8cOSU5OlsOHD0v37t1l4MCBynpLarr//vslNjZWTp06JT179pSgoCAREcnNzZWZM2dKu3btlHVb+4zT3YfBhOqc0t+4RYp/GHbu3PmWy27evFlcXV2V18OHD5cePXqUOb+1H7Klg8mIESPkoYceMptn9uzZ4u/vr7w2Go0SFhamvDaZTOLu7i6rV6+2ut3s7Gyxs7OTDRs2KG03btyQZs2aydKlS5W2Ro0a3fK3yNJHDCpTc+nlrAkJCZGZM2cqrysSTOzs7JRQKSISExMjDRs2lPz8fLN5W7VqVe6RJX9/f1m5cqWIiJw5c0YAmIWkxMREAaDsx7Jly8TX17fcIxylay0dTIxGoxQWFiptw4YNkyeeeKLMdbi4uMi6desqtH4R68GkSZMmkpOTo7StXr1anJ2dpaioSLKzs8XR0VEOHTpktp5x48bJ8OHDReTvz+zWrVvN5undu7c88MADZm333XefvPTSS2XuT+kxFBERIY0aNSpz/hI//PCDALA42rJnzx5lnm+++UYASF5enohY7x+6+/EaE7prdO3a1aJt3759eOihh+Dp6QkXFxeMGjUKV65cQU5ODgAgISEB/fr1q9Z2ExMT0aNHD7O2Hj164Ny5cygqKlLaOnbsqPxfo9GgadOmuHz5stV1Jicno6CgwGy9dnZ26NatGxITE6tVb2VqLq2oqAiLFi1Cx44d4erqCmdnZ0RHR+PChQuV2r7RaIRer1dex8fHIzs7W1lnyVdKSgqSk5MBADk5OXjxxRfh7++Pe+65B87OzkhKSlK2nZiYCFtbW7PPQdu2bc2uvRk2bBjy8vLQsmVLTJgwAV999VWlr7Vo164dGjRooLw2GAxlvo9A8QXK48ePx4MPPoglS5Yo+1MZnTp1gpOTk/I6MDAQ2dnZuHjxIk6fPo38/Hw89NBDZn33ySefWGzL2hi5+XNpbX9uNYbKcuLECTz22GMwGo1wcXFBcHAwAFh8Vm7evsFgAIBy+5PufgwmdNfQ6XRmr9PS0hASEoL27dtjy5YtiI+PR3h4OIC/L7jUarXV3q6IWFwIKyIW89nZ2Zm91mg0MJlMZa6zZJ5bbasqKlpzacuWLcPy5cvx4osvYu/evUhISMCAAQMqfbFx6ffKZDLBYDAgISHB7OvMmTOYPXs2AGD27NnYsmULFi1ahAMHDiAhIQEdOnRQtl1Wn93My8sLZ86cQXh4OLRaLaZMmYJevXpV6gLcyryPQPGdJadOncIjjzyCvXv3wt/fH1999RUAwMbGxqLfK1PLzdv+5ptvzPru9OnT+OKLL8zmL93vt9qfiowha3JyctC/f384OzsjMjISR48eVfa59Gfl5u2XvHfl9Sfd/SxvZyC6Sxw7dgyFhYVYtmwZbGyKM/jmzZvN5unYsSNiYmKwYMECq+uwt7cv9wgCAPj7++PgwYNmbYcOHYKvr6/Zb9aVce+998Le3h4HDx7EiBEjABT/IDh27FilnxFibR8qUrO15Q4cOIDHHnsMYWFhAIp/gJw7dw5+fn6Vqqm0gIAAXLp0Cba2tvDx8bE6z4EDBzBmzBgMGTIEAJCdnY3U1FRlup+fHwoLC3Hs2DF069YNAHDmzBmL581otVo8+uijePTRRzF16lS0bdsWP/30EwICAqq1D+Xx9fWFr68vZsyYgeHDhyMiIgJDhgyBXq/HpUuXzIKitefynDx5Enl5eUqQ/v777+Hs7IzmzZujcePGcHBwwIULF9C7d+8arbsiY8ja5yQpKQmZmZlYsmQJvLy8lHVVVkXGH919eMSE7lqtWrVCYWEhVq5cifPnz+PTTz/FmjVrzOZ55ZVXcPToUUyZMgU//vgjkpKSsHr1amRmZgIofpbHkSNHkJqaiszMTKu/yc2cORMxMTF4/fXXcfbsWaxfvx6rVq3CrFmzqly7TqfD5MmTMXv2bOzatQunT5/GhAkTkJubi3HjxlVqXT4+Pti/fz9+++03Zb8qUrO15e699158++23OHToEBITEzFp0iRcunSpyvtZ4sEHH0RgYCAef/xx7N69G6mpqTh06BBeffVV5Qfavffeiy+//BIJCQk4efIkRowYYfZ+tGnTBg8//DAmTJiAI0eOID4+HuPHjzc7KrZu3Tp89NFH+Pnnn5XPhFarhdForPY+WJOXl4dnn30WsbGxSEtLQ1xcHI4ePaoEueDgYGRkZGDp0qVITk5GeHg4du7cabGeGzduYNy4cTh9+jR27tyJefPm4dlnn4WNjQ1cXFwwa9YszJgxA+vXr0dycjJOnDiB8PBwrF+/vlr1V2QM+fj4IDs7GzExMcjMzERubi68vb1hb2+vLLdt2za8/vrrld6+j48PUlJSkJCQgMzMTFy/fr1a+0N1A4MJ3bU6d+6Md955B2+++Sbat2+PDRs2YPHixWbz+Pr6Ijo6GidPnkS3bt0QGBiI//73v8qzUWbNmoUGDRrA398fer3e6rUUAQEB2Lx5Mz777DO0b98er732GhYuXIgxY8ZUq/4lS5Zg6NCheOqppxAQEIBffvkFu3fvRuPGjSu1noULFyI1NRWtWrVSruuoSM3Wlps7dy4CAgIwYMAABAcHo2nTpjXyxFmNRoMdO3agV69eGDt2LHx9ffHkk08iNTUVHh4eAIDly5ejcePGCAoKwuDBgzFgwACLoxwRERHw8vJC79698c9//hMTJ06Eu7u7Mv2ee+7Bhx9+iB49eihHy77++uvb9qySBg0a4MqVKxg1ahR8fX0RGhqKgQMHKkfo/Pz88P777yM8PBydOnXCDz/8YDXQ9uvXD61bt0avXr0QGhqKwYMHY/78+cr0119/Ha+99hoWL14MPz8/DBgwAF9//TVatGhRrforMoaCgoLwzDPP4IknnoBer8fSpUuh1+uxbt06fP755/D398eSJUvw9ttvV3r7Q4cOxcMPP4w+ffpAr9dj06ZN1dofqhs0UpETy0REVCvGjBmDrKwsbN26tbZLIbojeMSEiIiIVIPBhIiIiFSDp3KIiIhINXjEhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhU4/8BJA9BxlSw+zgAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiYAAAFOCAYAAACygdbsAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAA9hAAAPYQGoP6dpAABBO0lEQVR4nO3dfVzN9/8/8MdJV6dTjDrVkS6wRbn8xEwZEmMa23x8ZGiYy8VsDLvwmbnYjNkMo2H7brGFZbP5mLlowlBmRBiFUWEyZfpYV1Tn+fvDr/fH6VS6ond63G+3bpzX+/V+v5/v9zmvcx69L04aEREQERERqYBFTRdAREREVITBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEatyAAQOg1WqRmZlZap9hw4bBysoKf/75J1avXg2NRoOUlJRqrWP27NnQaDR37Tdy5EjY29tX67prmkajwezZs2u6DLrPUlJSoNFosHr16nu2jvfeew+bNm0ya9+zZw80Gg327Nlzz9ZNtRODCdW40aNHIy8vD+vWrStx+n//+198//336NevH1xcXPDUU0/hwIEDMBgM97lSIqqo0oKJn58fDhw4AD8/v/tfFKkagwnVuL59+6Jx48b44osvSpy+fv165ObmYvTo0QAAvV6Pzp07w8bGpszl5uTkVHut91Ntr7+ycnNzwT/hdXe1/fVRv359dO7cGfXr16/pUkhlGEyoxtWrVw8jRoxAfHw8Tpw4YTY9IiICBoMBffv2BYAST+UEBgaidevW2Lt3LwICAmBnZ4dRo0YBAKKiotC7d28YDAZotVr4+PjgjTfeQHZ2dpXqPnnyJHr27AmdTge9Xo+XXnrJ7MMiPDwc3bp1g7OzM3Q6Hdq0aYOFCxciPz/fpF9Z9WdmZmLq1Klo1qwZbGxs4OzsjODgYCQlJSnz//XXX5gwYQLc3NxgbW2NZs2a4d///jdu3rxpsp4bN25g7NixcHR0hL29PZ588kmcOXOmxO07e/Yshg4dCmdnZ9jY2MDHxwfh4eHl2jcajQYvvfQSVq1aBW9vb9jY2MDX1xdff/21Sb+i5zI6OhqjRo2CXq+HnZ0dbt68CaPRiIULF6Jly5bKdg8fPhyXLl0yWYaI4L333oOnpydsbW3RsWNH/PTTTwgMDERgYKDZ9k+bNg1NmzaFtbU13NzcMHnyZLPXQlH9X331FXx8fGBnZ4d27dphy5YtSp99+/ZBo9Fg/fr1Ztv/5ZdfQqPR4NChQ6Xuo6Jt/+mnn/DCCy+gUaNG0Ol06N+/P86fP2/St6zXx4ULFxAaGmryPC1atAhGo9FkGZcvX0ZISAgcHBzQoEEDDB48GFeuXDGrq6T9Btw+henl5WXSdvPmTcydOxc+Pj6wtbWFo6MjevTogbi4OGU/ZmdnY82aNdBoNNBoNMqySzuVs3nzZvj7+8POzg4ODg544okncODAAZM+RaddT548iSFDhqBBgwZwcXHBqFGj8N///rfUfU61hBCpwNmzZ0Wj0cjkyZNN2k+ePCkA5I033lDaIiIiBIAkJycrbd27d5dGjRqJu7u7LFu2THbv3i0///yziIi88847snjxYvnxxx9lz549snLlSmnatKn06NHDZF2zZs2S8gyJESNGiLW1tXh4eMi8efMkOjpaZs+eLZaWltKvXz+TvlOmTJEVK1bI9u3bZdeuXbJ48WJxcnKSF154waRfafXfuHFDWrVqJTqdTubOnSs7duyQjRs3yiuvvCK7du0SEZHc3Fxp27at6HQ6+fDDDyU6OlpmzpwplpaWEhwcrKzDaDRKjx49xMbGRql71qxZ0qxZMwEgs2bNMtnvDRo0kDZt2siXX34p0dHRMnXqVLGwsJDZs2ffdR8BEHd3d/H19ZX169fL5s2b5cknnxQA8s033yj9ip5LNzc3GTdunGzbtk2+/fZbKSgokHHjxgkAeemll2T79u2ycuVK0ev14u7uLunp6coy3nzzTQEg48aNk+3bt8tnn30mHh4eYjAYpHv37kq/7Oxsad++vTg5OclHH30kO3fulKVLl0qDBg0kKChIjEajSf1eXl7SqVMn2bBhg2zdulUCAwPF0tJSzp07p/T7xz/+IV26dDHb/kcffVQeffTRMvdR0ba7u7vLqFGjZNu2bfLpp5+Ks7OzuLu7y/Xr15W+pb0+rl69Km5ubqLX62XlypWyfft2eemllwSAhIWFKfPn5OSIj4+PNGjQQJYtWyY7duyQl19+WTw8PASAREREmKzrzv1WZMSIEeLp6ak8zs/Plx49eoilpaVMmzZNtm7dKps3b5YZM2bI+vXrRUTkwIEDotVqJTg4WA4cOCAHDhyQkydPiojI7t27BYDs3r1bWebatWsFgPTu3Vs2bdokUVFR0qFDB7G2tpZ9+/Yp/YrGaosWLeTtt9+Wn376ST766COxsbExG1tU+zCYkGp0795dnJyc5NatW0rb1KlTBYCcOXNGaSstmACQmJiYMtdhNBolPz9ffv75ZwEgx44dU6ZVJJgAkKVLl5q0z5s3TwDI/v37S5yvsLBQ8vPz5csvv5R69erJX3/9ddf6586dKwDkp59+KrWelStXCgDZsGGDSfv7778vACQ6OlpERLZt21Zm3XcGkz59+kiTJk3kv//9r0nfl156SWxtbU1qLwkA0Wq1cuXKFaWtoKBAWrZsKQ8//LDSVvRcDh8+3GT+xMREASATJkwwaT948KAAkBkzZoiIyF9//SU2NjYyePBgk34HDhwQACYfsPPnzxcLCws5dOiQSd9vv/1WAMjWrVtN6ndxcZEbN24obVeuXBELCwuZP3++Wf1Hjx5V2n799VcBIGvWrClzHxXNO2DAAJP22NhYASDvvvuu0lba6+ONN94QAHLw4EGT9rCwMNFoNHL69GkREVmxYoUAkP/85z8m/caOHVvpYPLll18KAPnss8/K3E6dTicjRowway8eTAoLC6Vx48bSpk0bKSwsVPr9/fff4uzsLAEBAUpb0VhduHChyTInTJggtra2JiGTah+eyiHVGD16NDIyMrB582YAQEFBASIjI9G1a1c88sgjd52/YcOGCAoKMms/f/48hg4dCldXV9SrVw9WVlbo3r07ACAxMbHS9Q4bNszk8dChQwEAu3fvVtqOHj2Kp59+Go6Ojsq6hw8fjsLCQrNTKCXVv23bNnh7e6NXr16l1rFr1y7odDr861//MmkfOXIkACAmJsakrtLqLpKXl4eYmBgMGDAAdnZ2KCgoUH6Cg4ORl5eHX375pdR6ivTs2RMuLi7K43r16mHw4MH4/fffzU7HDBw40ORxUa1F21CkU6dO8PHxUbbpl19+wc2bNxESEmLSr3PnzmanHbZs2YLWrVujffv2JtvUp0+fEk8p9OjRAw4ODspjFxcXODs7IzU1VWkbMmQInJ2dTU5xLVu2DHq9HoMHDy5j7/xP8ecjICAAnp6eJq8joOTXx65du+Dr64tOnTqZtI8cORIigl27dgG4vT8dHBzw9NNPm/Qr/txXxLZt22Bra6ucUqqq06dP4/Lly3j++edhYfG/jyZ7e3sMHDgQv/zyi9mp0uLb07ZtW+Tl5eHq1avVUhPVDAYTUo1//etfaNCgASIiIgAAW7duxZ9//qlc9Ho3Jd2lk5WVha5du+LgwYN49913sWfPHhw6dAjfffcdgNsXWlaGpaUlHB0dTdpcXV0BANeuXQNw+9x/165d8ccff2Dp0qXYt28fDh06pHyIFV93SfWnp6ejSZMmZdZy7do1uLq6mt3q7OzsDEtLS6Wea9eulVn3ncsrKCjAsmXLYGVlZfITHBwMAMjIyCizppKWe2dbUU1Fim970fSS9knjxo1NtgmASQAqUrztzz//xPHjx822ycHBASJitk3F9xMA2NjYmDxvNjY2GD9+PNatW4fMzEykp6djw4YNGDNmzF0vzi5S2n662z4Cbm9/afuoaHrRvyXto5LWXV7p6elo3LixSYioirs950ajEdevXzdpL/4cFe3zyo5rUgfLmi6AqIhWq8WQIUPw2WefIS0tDV988QUcHBwwaNCgcs1f0neQ7Nq1C5cvX8aePXuUoyQAyvzOlPIoKCjAtWvXTN4Yiy4kLGrbtGkTsrOz8d1338HT01Ppl5CQUO769Xq92dGF4hwdHXHw4EGIiMkyrl69ioKCAjg5OSn9yqq7SMOGDVGvXj08//zzmDhxYonrbNq0aZk1lbTcO9uKf6AU3/ai6WlpaWbB7PLlyybbBNwOHSWt686jJk5OTtBqtaXe/VW0zIoKCwvDggUL8MUXXyAvLw8FBQV48cUXyz1/afvp4YcfNmkr6fXh6OiItLQ0s/bLly8DgMl++vXXX8u1bltb2xIvIC0e3PR6Pfbv3w+j0Vgt4eTO57y4y5cvw8LCAg0bNqzyekj9eMSEVGX06NEoLCzEBx98gK1bt+K5556DnZ1dpZdX9GZe/LfXVatWValOAFi7dq3J46LvYSm666CkdYsIPvvss3Kvo2/fvjhz5oxySL4kPXv2RFZWltl3RXz55ZfKdOD2qYmy6i5iZ2eHHj164OjRo2jbti06duxo9lPS0YTiYmJiTAJDYWEhoqKi0Lx587seBSo6ZREZGWnSfujQISQmJirb9Nhjj8HGxgZRUVEm/X755ReTUy4A0K9fP5w7dw6Ojo4lblPxUz/lZTAYMGjQIHzyySdYuXIl+vfvDw8Pj3LPX/z5iIuLQ2pqaol3xhTXs2dPnDp1CkeOHDFpL7orqOg579GjB/7++2/lNGmRkr47yMvLC2fOnDG5o+vatWvKnTZF+vbti7y8vLt+OVvxo0yladGiBdzc3LBu3TqT28Wzs7OxceNG5U4devDxiAmpSseOHdG2bVssWbIEIlLu0zilCQgIQMOGDfHiiy9i1qxZsLKywtq1a3Hs2LEqLdfa2hqLFi1CVlYWHn30UcTFxeHdd99F37598fjjjwMAnnjiCVhbW2PIkCF47bXXkJeXhxUrVpgdji7L5MmTERUVhWeeeQZvvPEGOnXqhNzcXPz888/o168fevTogeHDhyM8PBwjRoxASkoK2rRpg/379+O9995DcHCwcn1K79690a1bN7z22mvIzs5Gx44dERsbi6+++spsvUuXLsXjjz+Orl27IiwsDF5eXvj777/x+++/44cffigzKBVxcnJCUFAQZs6cCZ1Oh08++QRJSUlmtwyXpEWLFhg3bhyWLVsGCwsL9O3bFykpKZg5cybc3d0xZcoUAECjRo3w6quvYv78+WjYsCEGDBiAS5cuYc6cOTAYDCa/yU+ePBkbN25Et27dMGXKFLRt2xZGoxEXLlxAdHQ0pk6discee6y8T42JV155RZm36FRkeR0+fBhjxozBoEGDcPHiRfz73/+Gm5sbJkyYcNd5p0yZgi+//BJPPfUU5s6dC09PT/z444/45JNPEBYWBm9vbwDA8OHDsXjxYgwfPhzz5s3DI488gq1bt2LHjh1my3z++eexatUqhIaGYuzYsbh27RoWLlxo9n0jQ4YMQUREBF588UWcPn0aPXr0gNFoxMGDB+Hj44PnnnsOANCmTRvs2bMHP/zwAwwGAxwcHNCiRQuz9VpYWGDhwoUYNmwY+vXrh/Hjx+PmzZv44IMPkJmZiQULFlRov1ItVpNX3hKVZOnSpQJAfH19S5xe2l05rVq1KrF/XFyc+Pv7i52dnej1ehkzZowcOXLE7G6EityVo9Pp5Pjx4xIYGCharVYaNWokYWFhkpWVZdL3hx9+kHbt2omtra24ubnJ9OnTlbtj7rxNsqz6r1+/Lq+88op4eHiIlZWVODs7y1NPPSVJSUlKn2vXrsmLL74oBoNBLC0txdPTU958803Jy8szWVZmZqaMGjVKHnroIbGzs5MnnnhCkpKSzO7KERFJTk6WUaNGiZubm1hZWYler5eAgACTu0VKA0AmTpwon3zyiTRv3lysrKykZcuWsnbtWpN+Rc9l8TtlRG7fpfH++++Lt7e3WFlZiZOTk4SGhsrFixdN+hmNRnn33XelSZMmYm1tLW3btpUtW7ZIu3btzO54ycrKkrfeektatGgh1tbWyi3RU6ZMMbmDqKj+4jw9PUu8w0RExMvLS3x8fO66b4pve3R0tDz//PPy0EMPKbfWnj171qRvWa+P1NRUGTp0qDg6OoqVlZW0aNFCPvjgA5M7W0RELl26JAMHDhR7e3txcHCQgQMHSlxcnNk4EBFZs2aN+Pj4iK2trfj6+kpUVJTZXTkit29Vf/vtt+WRRx4Ra2trcXR0lKCgIImLi1P6JCQkSJcuXcTOzs7kTqmSbhcWEdm0aZM89thjYmtrKzqdTnr27CmxsbEmfYrG6p23jd+5T+98b6DaRyPCr1gkouql0WgwceJELF++vEbWn5ycjJYtW2LWrFmYMWPGPV/f8ePH0a5dO4SHh5frSAdw+wvWXnjhBRw6dAgdO3a8xxUS1R48lUNEtdqxY8ewfv16BAQEoH79+jh9+rRy6qGqpwLv5ty5c0hNTcWMGTNgMBjMbm8moopjMCGiWk2n0+Hw4cP4/PPPkZmZiQYNGiAwMBDz5s0r8RbZ6vTOO+8oX1v/zTff8OJMomrAUzlERESkGrxdmIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPfY1JBFy5cKNeffCei+8PJyanUP5rH8UqkLmWN1yIMJhVw4cIF+Pj4ICcnp6ZLIaL/z87ODomJiWZvdhyvROpT2ni9E4NJBWRkZCAnJweRkZHw8fGp6XKI6rzExESEhoYiIyPD7I2O45VIXcoar3diMKkEHx8f+Pn51XQZRFQOHK9EtQsvfiUiIiLVYDAhIiIi1eCpHKq1rl27hvHjx+PEiRPo378/srOzsWLFipoui4hKwPFK5cUjJlRrffXVV9DpdEhKSoLBYCj3fHFxcWjfvr1Ze1hYGBYtWmTSlp+fjzZt2iA4OLiq5RLVaVUZr25ubpgyZYpJO8frg4vBhGqtixcvokWLFtBoNPdsHTt37kRBQQFOnDiBpKSke7YeogddVcarVqvFli1bcPbs2TL7cbw+GBhMqFaaNGkSvv32W3z66ad45JFHsHXrVmVaSUdE+vXrh6ioqAqvJyoqCgMGDIC/v3+l5ieiqo9Xe3t7hIaG4v333y9zPRyvDwYGE6qVli1bhgEDBmDcuHE4e/bsPTl0m56ejt27d2PAgAEYOHAgvvvuO+Tn51f7eogedNUxXidNmoT9+/fj6NGjJU7neH1wMJhQnZSRkQEfHx+Tn23btpn02bhxI9zc3PDoo4/iqaeeQlZWFnbt2lVDFRPVbY0aNcL48eMxf/78EqdzvD44GEyoTnJyckJiYqLJT9++fU36bNiwAQMGDABw+1Bynz59eHiYqAaNGzcOSUlJ2Lt3r9k0jtcHB28XpgeOTqdDbm6uSVt6enqFlnH06FGcPn0aV65cwdq1awEAubm5yMvLQ0ZGBpycnKqtXqK6rCLjVafT4eWXX8aCBQvg6emptHO8Plh4xIQeOM2aNUNhYSG2bt2KgoICrF69GleuXKnQMqKiotC5c2fs2bMH0dHRiI6Oxt69e+Hq6oqNGzfeo8qJ6p6Kjtfhw4fj2rVr2Ldvn9LG8fpgYTChB46DgwMWLFiAmTNnol27drh69SratGlT7vnz8vKwefNmjBw5Es7OzsqPi4sLhg8fjg0bNtzD6onqloqOV2tra7z66qu4fv06AI7XB5FGRKSmi6gtjhw5gg4dOiA+Pp5/FIxIBcoakxyvROpS3jHJIyZERESkGgwmREREpBoMJkRERKQavF24AopuaUtISKjZQogIAJCYmFjqNI5XInUpa7zeicGkAjIzMwEAo0ePrtlCiEhhZ2dX4vdUcLwSqU9p4/VODCYVUPSnuiMjI+Hj41PD1RARcPtbfD08PMzaOV6J1Ke08XonBpNK8PHx4e2HRLUExytR7cKLX4mIiEg1GEyIiIhINRhMiIiISDUYTIiIiEg1GEyIiIhINRhMiIiISDUYTIiIiEg1GEyIiIhINfgFa/fI0KFDzdrWrVtXA5UQERHVHjxiQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKphWZMr37JlC3bt2oWUlBT4+/tj+vTpyrQxY8YgMzMTFha3s5Ner0d4eLgyPTY2FqtXr0ZmZiZ8fHzwyiuvwNHRUZkeGRmJbdu2wWg0omvXrhg3bhwsLW9vblZWFsLDw3HkyBFotVqEhIQgODj4Pm01ERERlaZGg0mjRo0QEhKChIQE/P3332bT33zzTXTo0MGs/dKlS/j444/x5ptvwsfHBxEREfjwww8xf/58AEB0dDT27t2Ljz76CLa2tnjnnXewYcMGDB06FACwatUqFBYWIiIiAmlpaXj77bfRpEkTtG3b9t5uMBEREZWpRk/lBAQEoHPnzqhfv36F5tu9ezf8/PzQvn172NjYYNiwYUhKSkJaWhoAYOfOnXj22Wfh4uKCBg0aICQkBDt37gQA5OXlITY2FqGhobCzs0Pz5s0RFBSkTCciIqKaU6NHTO5myZIlEBF4eHggNDQUvr6+AIDU1FR4e3sr/RwcHKDX65GamgqDwYALFy7Ay8tLmd60aVNkZGQgOzsbV65cAQB4eHgo05s1a4ZNmzaVWENaWpoSeBITE6t5C4mIiOhOqg0mr776Kpo3bw4AiImJwZw5c7Bs2TI4OzsjLy8PdnZ2Jv11Oh1yc3MB3D4qotPpTKYBQG5uLvLy8qDVakudt7hVq1Zhzpw51bZdREREVDrV3pXj6+sLGxsb2NjYIDg4GM2aNUN8fDwAwNbWFjk5OSb9s7OzlcBRfHrR/7VaLWxtbc1CyJ3zFjd+/HjEx8cjPj4ekZGR1bZ9REREZE61R0yKs7CwgIgAADw9PZGSkqJMy8rKQkZGBjw9PQHcPk2TnJwMHx8fAEBycjKcnJyg0+ng5uYGALh48SLc3d2V6UXzFmcwGGAwGO7VZhEREdEdavSISWFhIW7dugWj0Qij0Yhbt26hoKAA6enpOHnyJPLz85Gfn48dO3bg7Nmz+Mc//gEACAwMRHx8PI4dO4abN29i7dq1aNGihRIgevbsic2bN+Pq1au4ceMGoqKi0KtXLwC3j6Z06dIFa9euRU5ODpKTkxETE4OePXvW2H4gIiKi22r0iElUVBS+/vpr5XFsbCyCgoLwz3/+E59++inS0tJgaWkJd3d3zJw5Uwke7u7umDRpEpYvX47r16/D19cX06ZNU5bTu3dvpKenY8qUKSgsLES3bt0QEhKiTB8/fjyWL1+OkSNHws7ODsOGDUO7du3u34YTERFRiTRSdH6E7urIkSPo0KED4uPj4efnV2bfou9MudO6devuVWlEVExFxisRqYdqL34lIiKiuofBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUo1LBJCgoCJmZmWbtN27cQFBQUFVrIiIiojqqUsFkz549uHXrlll7Xl4e9u3bV+WiiIiIqG6yrEjn48ePK/8/deoUrly5ojwuLCzE9u3b4ebmVn3VERERUZ1SoWDSvn17aDQaaDSaEk/ZaLVaLFu2rNzL27JlC3bt2oWUlBT4+/tj+vTpyrTU1FQsW7YMKSkpcHV1RVhYGFq1aqVMj42NxerVq5GZmQkfHx+88sorcHR0VKZHRkZi27ZtMBqN6Nq1K8aNGwdLy9ubm5WVhfDwcBw5cgRarRYhISEIDg6uyK4gIiKie6BCp3KSk5Nx7tw5iAh+/fVXJCcnKz9//PEHbty4gVGjRpV7eY0aNUJISAh69+5t0l5QUIB3330X/v7+WL9+PQYOHIh58+YhKysLAHDp0iV8/PHHmDhxIiIjI9G4cWN8+OGHyvzR0dHYu3cvPvroI6xcuRLnz5/Hhg0blOmrVq1CYWEhIiIiMHPmTKxdu9bkaBARERHVjAoFE09PT3h5ecFoNKJjx47w9PRUfgwGA+rVq1ehlQcEBKBz586oX7++SfuJEydw8+ZNDBgwAFZWVujRowdcXFwQFxcHANi9ezf8/PzQvn172NjYYNiwYUhKSkJaWhoAYOfOnXj22Wfh4uKCBg0aICQkBDt37gRw+zqY2NhYhIaGws7ODs2bN0dQUJAynYiIiGpOhU7l3OnMmTPYs2cPrl69CqPRaDLt7bffrlJRFy5cgKenJyws/pebmjZtigsXLgC4fZrH29tbmebg4AC9Xo/U1FQYDAZcuHABXl5eJvNmZGQgOztbuS7Gw8NDmd6sWTNs2rSpxFrS0tKUwJOYmFil7SIiIqKyVSqYfPbZZwgLC4OTkxNcXV2h0WiUaRqNpsrBJDc3FzqdzqRNp9MhJycHwO2jHnZ2dmbTc3Nzlel3zl/0/9zcXOTl5UGr1ZY6b3GrVq3CnDlzqrQ9REREVD6VCibvvvsu5s2bh9dff7266wFw+yLaohBSJCcnRwkUtra2ZtOzs7NLnV70f61WC1tbW7MQcue8xY0fPx5PP/00gNtHTEJDQ6uwZURU2w0dOtSsbd26dTVQCdGDqVLfY3L9+nUMGjSoumtReHh4IDU11eQUUXJysnL6xdPTEykpKcq0rKwsZGRkwNPTU5k/OTnZZF4nJyfodDrlduaLFy+aTC+atziDwQA/Pz/4+fnBx8en2raRiIiIzFUqmAwaNAjR0dFVXnlhYSFu3boFo9EIo9GIW7duoaCgAG3atIGVlRU2bdqE/Px8/Pzzz7hy5Qr8/f0BAIGBgYiPj8exY8dw8+ZNrF27Fi1atIDBYAAA9OzZE5s3b8bVq1dx48YNREVFoVevXgBuH03p0qUL1q5di5ycHCQnJyMmJgY9e/as8vYQERFR1VTqVM7DDz+MmTNn4pdfflFCxJ1efvnlci0nKioKX3/9tfI4NjYWQUFBmDx5Mt566y0sX74c69atg4uLC2bMmAEHBwcAgLu7OyZNmoTly5fj+vXr8PX1xbRp05Tl9O7dG+np6ZgyZQoKCwvRrVs3hISEKNPHjx+P5cuXY+TIkbCzs8OwYcPQrl27yuwKInoA8PQMkXpoREQqOlPTpk1LX6BGg/Pnz1epKLU6cuQIOnTogPj4ePj5+ZXZl290RDXrXo1Xjm2ie6tSR0zuvH6DiIiIqLpU6hoTIiIionuhUkdM7va181988UWliiEiIqK6rVLB5Pr16yaP8/Pz8dtvvyEzM7PEP+5HREREVB6VCibff/+9WZvRaMSECRPQrFmzKhdFREREdVO1XWNiYWGBKVOmYPHixdW1SCIiIqpjqvXi13PnzqGgoKA6F0lERER1SKVO5bz66qsmj0UEaWlp+PHHHzFixIhqKYyIiIjqnkoFk6NHj5o8trCwgF6vx6JFi+56xw4RERFRaSoVTHbv3l3ddRARERFVLpgUSU9Px+nTp6HRaODt7Q29Xl9ddREREVEdVKmLX7OzszFq1CgYDAZ069YNXbt2RePGjTF69Gjk5ORUd41ERERUR1QqmLz66qv4+eef8cMPPyAzMxOZmZn4z3/+g59//hlTp06t7hqJiIiojqjUqZyNGzfi22+/RWBgoNIWHBwMrVaLkJAQrFixorrqIyIiojqkUkdMcnJy4OLiYtbu7OzMUzlERERUaZUKJv7+/pg1axby8vKUttzcXMyZMwf+/v7VVhwRERHVLZU6lbNkyRL07dsXTZo0Qbt27aDRaJCQkAAbGxtER0dXd41ERERUR1QqmLRp0wZnz55FZGQkkpKSICJ47rnnMGzYMGi12uqukYiIiOqISgWT+fPnw8XFBWPHjjVp/+KLL5Ceno7XX3+9WoojIiKiuqVS15isWrUKLVu2NGtv1aoVVq5cWeWiiIiIqG6qVDC5cuUKDAaDWbter0daWlqViyIiIqK6qVLBxN3dHbGxsWbtsbGxaNy4cZWLIiIiorqpUteYjBkzBpMnT0Z+fj6CgoIAADExMXjttdf4za9ERERUaZUKJq+99hr++usvTJgwAbdu3QIA2Nra4vXXX8ebb75ZrQUSERFR3VGpYKLRaPD+++9j5syZSExMhFarxSOPPAIbG5vqro+IiIjqkEoFkyL29vZ49NFHq6sWIiIiquMqdfErERER0b3AYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqsFgQkRERKrBYEJERESqwWBCREREqmFZ0wWUZcmSJdi7dy8sLf9XZnh4OPR6PQAgNTUVy5YtQ0pKClxdXREWFoZWrVopfWNjY7F69WpkZmbCx8cHr7zyChwdHZXpkZGR2LZtG4xGI7p27Ypx48aZrIuIiIjuL9UfMXnmmWewYcMG5acolBQUFODdd9+Fv78/1q9fj4EDB2LevHnIysoCAFy6dAkff/wxJk6ciMjISDRu3Bgffvihstzo6Gjs3bsXH330EVauXInz589jw4YNNbKNREREdJvqg0lpTpw4gZs3b2LAgAGwsrJCjx494OLigri4OADA7t274efnh/bt28PGxgbDhg1DUlIS0tLSAAA7d+7Es88+CxcXFzRo0AAhISHYuXNnTW4SERFRnaf68xY7duzAjh074OTkhP79++OJJ54AAFy4cAGenp6wsPhftmratCkuXLgA4PZpHm9vb2Wag4MD9Ho9UlNTYTAYcOHCBXh5eZnMm5GRgezsbOh0uvuzcf/f0KFDzdrWrVt3X2sgIiJSA1UHk/79+2PUqFHQ6XQ4deoUFixYAJ1Oh4CAAOTm5poFCJ1Oh5ycHABAXl4e7OzszKbn5uYq0++cv+j/xZeblpamHGVJTEys/o0kIiIihaqDSfPmzZX/t2nTBk899RRiY2MREBAArVarhJAiOTk50Gq1AABbW1uz6dnZ2aVOL/p/0fQiq1atwpw5c6pvo4iIiKhUteoaE41GAxEBAHh4eCA1NRVGo1GZnpycDA8PDwCAp6cnUlJSlGlZWVnIyMiAp6enMn9ycrLJvE5OTmZHYcaPH4/4+HjEx8cjMjLyXm0aERERQeXBZP/+/cjJyYHRaMSpU6fw448/onPnzgBuH0GxsrLCpk2bkJ+fj59//hlXrlyBv78/ACAwMBDx8fE4duwYbt68ibVr16JFixYwGAwAgJ49e2Lz5s24evUqbty4gaioKPTq1cusBoPBAD8/P/j5+cHHx+f+bTwREVEdpOpTOVu2bEF4eDiMRiOcnJwwbNgwdOvWDQBgaWmJt956C8uXL8e6devg4uKCGTNmwMHBAQDg7u6OSZMmYfny5bh+/Tp8fX0xbdo0Zdm9e/dGeno6pkyZgsLCQnTr1g0hISE1sp1ERER0m6qDyYIFC8qc7uXlZfLdJMU9/vjjePzxx0ucptFoEBoaitDQ0CrVSERERNVH1adyiIiIqG5hMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1bCs6QKIiB5EQ4cONWtbt25dDVRCVLvwiAkRERGpBoMJERERqQaDCREREakGgwkRERGpBoMJERERqQaDCREREakGgwkRERGpBoMJERERqQaDCREREakGgwkRERGpBoMJERERqQb/Vk4twr+9QUREDzoeMSEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1eBdObUc79QhIqIHCY+YEBERkWowmBAREZFqMJgQERGRajCYEBERkWrw4lciovuEF6sT3R2DCRFRDSoprAAMLFR3MZgQERFVEI9+3TsMJkTVhG9URERVx4tfiYiISDV4xISISIV4BI7qKh4xISIiItWo00dMsrKyEB4ejiNHjkCr1SIkJATBwcE1XdY9w9/AiIgqprS7pujeqdPBZNWqVSgsLERERATS0tLw9ttvo0mTJmjbtm1Nl1YlHEi1U3mfN4bJuou/XFBdUGeDSV5eHmJjY7FkyRLY2dmhefPmCAoKws6dO2t9MKG6hx9YROrEsVlxdTaY/PHHHwAADw8Ppa1Zs2bYtGlTDVVUMzho7r+qHtEq7/z84q66gWO49qnIe0BdfC7rbDDJy8uDVqs1adPpdMjNzTVpS0tLQ1paGgAgMTHxvtVXk3gqqPqocV/WZE118U22JqjxdVcX3Iv9Xhuey+oe13U2mNja2pqFkOzsbLOwsmrVKsyZM6fCy6/IE1XevnxTJ7o3OF6J1KPO3i7s5uYGALh48aLSlpycDE9PT5N+48ePR3x8POLj4xEZGXlfayQiIqpr6mwwsbW1RZcuXbB27Vrk5OQgOTkZMTEx6Nmzp0k/g8EAPz8/+Pn5wcfHp4aqJSIiqhvq7Kkc4PbRkOXLl2PkyJGws7PDsGHD0K5du5oui4iIqM6q08HE3t4eb7zxRk2XQURERP9fnT2VQ0REROrDYEJERESqwWBCREREqsFgQkRERKpRpy9+raiiL2SrK98AS1RbtGzZEnZ2diZtHK9E6lTSeL0Tg0kFpKSkAABCQ0NrthAiMhEfHw8/Pz+TNo5XInUqabzeSSMich/rqdUyMjKwY8cOeHl5mX11fU1ITExEaGgoIiMjVf3lb6yzerFOcyX9BsbxWjmss3qxTnM8YlKNnJycMGzYsJouw4yPj0+Z6VMtWGf1Yp1l43itGtZZvVhn+fHiVyIiIlINBpNazGAwYNasWTAYDDVdSplYZ/VinbVTbdkfrLN6sc6K4zUmREREpBo8YkJERESqwWBCREREqsFgQkRERKrB24VVZsuWLdi1axdSUlLg7++P6dOnV3pZRqMRUVFR+Omnn5CVlQW9Xo+33nqrWi5uqs46x4wZg8zMTFhY3M7Jer0e4eHhVa6xuusscuLECfz73//GwIEDMWLEiGqosvrqzM3NxZw5c3Dx4kUUFBTA1dUVQ4YMQefOnVVV5x9//IHVq1cjKSkJBQUF8PT0xOjRo/HII49US533C8crxyvHa/VjMFGZRo0aISQkBAkJCfj777+rtKyvv/4aJ06cwHvvvQcXFxdcvnwZDg4OqqsTAN5880106NChGiozVd115ufn47PPPkPLli2robr/qa46raysMGHCBLi5uaFevXpITEzE7Nmz8cknn8DR0VE1dWZnZ6NDhw6YNGkSdDodtm3bhjlz5uD//u//YGtrW+U67xeO1+rF8crxCjCYqE5AQAAA4Pz582YvpLNnz+Lzzz9HamoqGjZsiNDQUKV/cVlZWdi0aROWLFkCV1dXAICbm5vq6rzXqrvOb775Bp06dUJGRoYq67S0tISHhwcAQESg0WhQUFCAq1evVssbXXXV6e3tDW9vb+Vxv379sHr1aly6dAkPP/xwleu8XzheqxfHK8crwGBSa/z111+YPXs2Jk2ahEcffRS///475syZA3d3d7i7u5v1T01NRb169RAXF4fNmzfD1tYWQUFBGDx4MDQajWrqLLJkyRKICDw8PBAaGgpfX997VmNl6/zjjz+wb98+LFmyBCtWrLin9VWlTgB44403cObMGRQUFKBdu3YmbypqqrPI2bNnISKq+A6F6sDxWvN1crxWf51F7vV45cWvtcTu3bvRrl07dO7cGfXq1UOLFi3QuXNnxMbGltg/IyMD2dnZuHjxIj799FPMmjULO3fuRExMjKrqBIBXX30V//d//4fPP/8cjz/+OObMmYOrV6+qrs5PPvkEL7zwAmxsbO5pbVWtEwAWLFiAqKgozJgxAx06dEC9evVUWScA3LhxAx999BGGDRsGnU53T+u8Xzhea75OjtfqrxO4P+OVR0xqiatXr+LgwYMYMmSI0lZYWIjAwECkp6dj4sSJSnt4eLgyGJ977jnY2trCzc0NvXv3xuHDh9GrVy/V1KnX601+2woODsa+ffsQHx+Pvn37qqbOEydOQKvVolOnTvespuqoU6/XK4+trKzQuXNnvPXWW2jcuPE9rb2ydWZnZ2POnDnw8/PDP//5z3tW3/3G8VqzdXK83ps679d4ZTCpJfR6Pbp27YrJkyeXOH3Dhg0mjwsLCwHgnh4GLklF6yyJhYUF7vUXEle0zuPHj+PEiRPKH4XLy8uDRqPBmTNnMG/ePNXUWZLCwkKkpaVVc2WmKlNnTk4OZs2ahebNm2Ps2LH3tL77jeO1enG8Vi+1j1eeylGZwsJC3Lp1C0ajEUajEbdu3UJBQQECAwMRHx+PX3/9FYWFhcjPz8fp06dx8eLFEpfj6uqKNm3aICoqCrdu3cKVK1cQHR2Nxx57TFV1pqen4+TJk8jPz0d+fj527NiBs2fP4h//+Ieq6hwzZgzCw8OxdOlSLF26FJ06dUKvXr2q5XbG6qzz3LlzOH78uLI/o6Ojcfr0abRu3VpVdRa9ybm7uyMsLKxaaqsJHK8crxyv1Y9/K0dl1q1bh6+//tqkLSgoCJMnT8bZs2exZs0aJCcnAwC8vLwwevRoNGvWrMRl/fXXX1i+fDl+++032NvbIzg4GP/6179UVeeFCxewaNEipKWlwdLSEu7u7ggNDUWbNm1UVWdxS5YsQcOGDavtexGqq87Tp09j5cqVuHz5MiwsLODm5oZBgwZV2wdcddUZExODpUuXwsbGxuQowaxZs9CqVatqqfV+4HjleK1KnRyvJWMwISIiItXgqRwiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GE6p1RATjxo1Do0aNoNFokJCQcF/Xv2fPHmg0GmRmZt7X9ZYkNjYWbdq0gZWVFZ599tmaLgcAEBgYWOrf4KgJXl5eWLJkSaXmnT17Ntq3b1+t9RBR2RhMqNbZvn07Vq9ejS1btiAtLa3a/q5ESUr6kA0ICEBaWhoaNGhwz9ZbXq+++irat2+P5ORkrF69usQ+lf1grsoH+oNi2rRpiImJqekyVG316tV46KGH7smyGQzrJgYTqnXOnTsHg8GAgIAAuLq6wtLS/I9k37p1656t39raGq6urvf9L8GW5Ny5cwgKCkKTJk3u2YfDvZafn1/TJZTK3t4ejo6ONV1GtRMRFBQU1HQZRCUTolpkxIgRAkD58fT0FBGR7t27y8SJE2XKlCni6Ogo3bp1ExGRRYsWSevWrcXOzk6aNGkiYWFh8vfff5ssc//+/dKtWzfRarXy0EMPSe/eveWvv/4yWxcASU5Olt27dwsAuX79urKMb7/9Vnx9fcXa2lo8PT3lww8/NFmHp6enzJs3T1544QWxt7cXd3d3WbVqVZnbmpeXJ5MmTRK9Xi82NjbSpUsX+fXXX0VEJDk52ay2iIgIs2V0797drF95ai5tvoyMDHnuuefEzc1NtFqttG7dWtatW2e2zldeeaXU7Zo1a5a0a9dOPv/8c2natKloNBoxGo2SmZkpY8eOFb1eLw4ODtKjRw9JSEhQ5vv999/l6aefFmdnZ9HpdNKxY0f56aefTJb9559/Sr9+/cTW1la8vLwkMjJSPD09ZfHixSbrd3d3F2trazEYDDJp0qS71lpkxIgR8swzz8gHH3wgrq6u0qhRI5kwYYLcunWr1GUkJCRIYGCg2Nvbi4ODg/j5+cmhQ4dKXL6IyOLFi5XX9Z3rnD17trJvxo0bJzdv3lT6GI1Gef/996Vp06Zia2srbdu2lW+++UaZXvSa3b59u3To0EGsrKxk165d0r17d5k0aZJMnz5dGjZsKC4uLjJr1iyTesoaQ0XLvfOnaP6vvvpKOnToIPb29uLi4iJDhgyRP//806ymnTt3SocOHUSr1Yq/v78kJSWJiEhERES5XuP04GEwoVolMzNT5s6dK02aNJG0tDS5evWqiNz+MLS3t5fp06dLUlKSJCYmisjtN/ldu3bJ+fPnJSYmRlq0aCFhYWHK8o4ePSo2NjYSFhYmCQkJ8ttvv8myZcskPT1dMjMzxd/fX8aOHStpaWmSlpYmBQUFZsHk8OHDYmFhIXPnzpXTp09LRESEaLVakzdRT09PadSokYSHh8vZs2dl/vz5YmFhodRZkpdfflkaN24sW7dulZMnT8qIESOkYcOGcu3aNSkoKJC0tDSpX7++LFmyRNLS0iQnJ8dsGdeuXZMmTZrI3LlzlW0oT82lzXfp0iX54IMP5OjRo3Lu3Dn5+OOPpV69evLLL78o6yxPMNHpdNKnTx85cuSIHDt2TIxGo3Tp0kX69+8vhw4dkjNnzsjUqVPF0dFRrl27JiK3P+BXrlwpx48flzNnzsi///1vsbW1ldTUVGXZffv2ldatW0tcXJwcPnxYAgICRKvVKsHkm2++kfr168vWrVslNTVVDh48KJ9++mmZtRYPJvXr15cXX3xREhMT5YcffhA7O7syl9GqVSsJDQ2VxMREOXPmjGzYsEEJXOUNJvb29jJ48GD57bffZMuWLaLX62XGjBlKnxkzZkjLli1l+/btcu7cOYmIiBAbGxvZs2ePiPwvBLRt21aio6Pl999/l4yMDOnevbvUr19fZs+eLWfOnJE1a9aIRqOR6Ohok3pKG0M3b96UJUuWSP369ZXXSVFo+fzzz2Xr1q1y7tw5OXDggHTu3Fn69u2rLLeopscee0z27NkjJ0+elK5du0pAQICIiOTk5MjUqVOlVatWyrJLeo3Tg4fBhGqd4m/cIrc/DNu3b3/XeTds2CCOjo7K4yFDhkiXLl1K7V/Sh2zxYDJ06FB54oknTPpMnz5dfH19lceenp4SGhqqPDYajeLs7CwrVqwocb1ZWVliZWUla9euVdpu3boljRs3loULFyptDRo0uOtvkcWPGFSk5uLzlSQ4OFimTp2qPC5PMLGyslJCpYhITEyM1K9fX/Ly8kz6Nm/evMwjS76+vrJs2TIRETl9+rQAMAlJiYmJAkDZjkWLFom3t3eZRziK11o8mHh6ekpBQYHSNmjQIBk8eHCpy3BwcJDVq1eXa/kiJQeTRo0aSXZ2ttK2YsUKsbe3l8LCQsnKyhJbW1uJi4szWc7o0aNlyJAhIvK/1+ymTZtM+nTv3l0ef/xxk7ZHH31UXn/99VK3p/gYioiIkAYNGpTav8ivv/4qAMyOtuzcuVPp8+OPPwoAyc3NFZGS9w89+HiNCT0wOnbsaNa2e/duPPHEE3Bzc4ODgwOGDx+Oa9euITs7GwCQkJCAnj17Vmm9iYmJ6NKli0lbly5dcPbsWRQWFiptbdu2Vf6v0Wjg6uqKq1evlrjMc+fOIT8/32S5VlZW6NSpExITE6tUb0VqLq6wsBDz5s1D27Zt4ejoCHt7e0RHR+PChQsVWr+npyf0er3yOD4+HllZWcoyi36Sk5Nx7tw5AEB2djZee+01+Pr64qGHHoK9vT2SkpKUdScmJsLS0tLkddCyZUuTa28GDRqE3NxcNGvWDGPHjsX3339f4WstWrVqhXr16imPDQZDqc8jcPsC5TFjxqBXr15YsGCBsj0V0a5dO9jZ2SmP/f39kZWVhYsXL+LUqVPIy8vDE088YbLvvvzyS7N1lTRG7nxdlrQ9dxtDpTl69CieeeYZeHp6wsHBAYGBgQBg9lq5c/0GgwEAytyf9OBjMKEHhk6nM3mcmpqK4OBgtG7dGhs3bkR8fDzCw8MB/O+CS61WW+X1iojZhbAiYtbPysrK5LFGo4HRaCx1mUV97rauyihvzcUtWrQIixcvxmuvvYZdu3YhISEBffr0qfDFxsWfK6PRCIPBgISEBJOf06dPY/r06QCA6dOnY+PGjZg3bx727duHhIQEtGnTRll3afvsTu7u7jh9+jTCw8Oh1WoxYcIEdOvWrUIX4FbkeQRu31ly8uRJPPXUU9i1axd8fX3x/fffAwAsLCzM9ntFarlz3T/++KPJvjt16hS+/fZbk/7F9/vdtqc8Y6gk2dnZ6N27N+zt7REZGYlDhw4p21z8tXLn+oueu7L2Jz34zG9nIHpAHD58GAUFBVi0aBEsLG5n8A0bNpj0adu2LWJiYjBnzpwSl2FtbV3mEQQA8PX1xf79+03a4uLi4O3tbfKbdUU8/PDDsLa2xv79+zF06FAAtz8IDh8+XOHvCClpG8pTc0nz7du3D8888wxCQ0MB3P4AOXv2LHx8fCpUU3F+fn64cuUKLC0t4eXlVWKfffv2YeTIkRgwYAAAICsrCykpKcp0Hx8fFBQU4PDhw+jUqRMA4PTp02bfN6PVavH000/j6aefxsSJE9GyZUucOHECfn5+VdqGsnh7e8Pb2xtTpkzBkCFDEBERgQEDBkCv1+PKlSsmQbGk7+U5duwYcnNzlSD9yy+/wN7eHk2aNEHDhg1hY2ODCxcuoHv37tVad3nGUEmvk6SkJGRkZGDBggVwd3dXllVR5Rl/9ODhERN6YDVv3hwFBQVYtmwZzp8/j6+++gorV6406fPmm2/i0KFDmDBhAo4fP46kpCSsWLECGRkZAG5/l8fBgweRkpKCjIyMEn+Tmzp1KmJiYvDOO+/gzJkzWLNmDZYvX45p06ZVunadToewsDBMnz4d27dvx6lTpzB27Fjk5ORg9OjRFVqWl5cX9u7diz/++EPZrvLUXNJ8Dz/8MH766SfExcUhMTER48ePx5UrVyq9nUV69eoFf39/PPvss9ixYwdSUlIQFxeHt956S/lAe/jhh/Hdd98hISEBx44dw9ChQ02ejxYtWuDJJ5/E2LFjcfDgQcTHx2PMmDEmR8VWr16Nzz//HL/99pvymtBqtfD09KzyNpQkNzcXL730Evbs2YPU1FTExsbi0KFDSpALDAxEeno6Fi5ciHPnziE8PBzbtm0zW86tW7cwevRonDp1Ctu2bcOsWbPw0ksvwcLCAg4ODpg2bRqmTJmCNWvW4Ny5czh69CjCw8OxZs2aKtVfnjHk5eWFrKwsxMTEICMjAzk5OfDw8IC1tbUy3+bNm/HOO+9UeP1eXl5ITk5GQkICMjIycPPmzSptD9UODCb0wGrfvj0++ugjvP/++2jdujXWrl2L+fPnm/Tx9vZGdHQ0jh07hk6dOsHf3x//+c9/lO9GmTZtGurVqwdfX1/o9foSr6Xw8/PDhg0b8PXXX6N169Z4++23MXfuXIwcObJK9S9YsAADBw7E888/Dz8/P/z+++/YsWMHGjZsWKHlzJ07FykpKWjevLlyXUd5ai5pvpkzZ8LPzw99+vRBYGAgXF1dq+UbZzUaDbZu3Ypu3bph1KhR8Pb2xnPPPYeUlBS4uLgAABYvXoyGDRsiICAA/fv3R58+fcyOckRERMDd3R3du3fHP//5T4wbNw7Ozs7K9IceegifffYZunTpohwt++GHH+7Zd5XUq1cP165dw/Dhw+Ht7Y2QkBD07dtXOULn4+ODTz75BOHh4WjXrh1+/fXXEgNtz5498cgjj6Bbt24ICQlB//79MXv2bGX6O++8g7fffhvz58+Hj48P+vTpgx9++AFNmzatUv3lGUMBAQF48cUXMXjwYOj1eixcuBB6vR6rV6/GN998A19fXyxYsAAffvhhhdc/cOBAPPnkk+jRowf0ej3Wr19fpe2h2kEj5TmxTERENWLkyJHIzMzEpk2baroUovuCR0yIiIhINRhMiIiISDV4KoeIiIhUg0dMiIiISDUYTIiIiEg1GEyIiIhINRhMiIiISDUYTIiIiEg1GEyIiIhINRhMiIiISDUYTIiIiEg1/h/Ex3bhfmVzQQAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 600x300 with 2 Axes>"
       ]
@@ -1056,7 +1324,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776402377235)>"
+       "<ggplot: (8783972809213)>"
       ]
      },
      "metadata": {},
@@ -1088,9 +1356,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/fh/fast/bloom_j/software/miniconda3/envs/barcoded_flu_pdmH1N1/lib/python3.8/site-packages/pandas/core/series.py:726: RuntimeWarning: divide by zero encountered in log10\n",
+      "/fh/fast/bloom_j/software/miniconda3/envs/barcoded_flu_pdmH1N1/lib/python3.8/site-packages/plotnine/layer.py:372: PlotnineWarning: stat_bin : Removed 8755 rows containing non-finite values.\n"
+     ]
+    },
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiYAAAFOCAYAAACygdbsAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAA9hAAAPYQGoP6dpAABBHklEQVR4nO3dfVzN9/8/8MdJV6dTjDrVkTphi3L5iZkyJMY0tvn4yNAwl4vZGHbhM3OxGbMZRsP23WILy2bzMXPRhKHMiDAKS4XJlOljXVGd5+8Pv94fpytd0Zse99utm87r/Xq/38/3+5xXPbyv0oiIgIiIiEgFLGq7ACIiIqIiDCZERESkGgwmREREpBoMJkRERKQaDCZERESkGgwmREREpBoMJkRERKQaDCZERESkGgwmREREpBoMJlTrBgwYAK1Wi8zMzDL7DBs2DFZWVvjzzz+xevVqaDQapKSk1Ggds2fPhkajuWO/kSNHwt7evkbXXds0Gg1mz55d22XQPZaSkgKNRoPVq1fftXW899572LRpU4n2PXv2QKPRYM+ePXdt3XR/YjChWjd69Gjk5eVh3bp1pU7/73//i++//x79+vWDi4sLnnrqKRw4cAAGg+EeV0pElVVWMPH19cWBAwfg6+t774siVWMwoVrXt29fNG7cGF988UWp09evX4/c3FyMHj0aAKDX69G5c2fY2NiUu9ycnJwar/Veut/rr6rc3FzwT3jd2f3++ahfvz46d+6M+vXr13YppDIMJlTr6tWrhxEjRiAuLg4nTpwoMT08PBwGgwF9+/YFgFJP5QQEBKB169bYu3cv/P39YWdnh1GjRgEAIiMj0bt3bxgMBmi1Wnh7e+ONN95AdnZ2teo+efIkevbsCZ1OB71ej5deeqnEL4uwsDB069YNzs7O0Ol0aNOmDRYuXIj8/HyzfuXVn5mZialTp6JZs2awsbGBs7MzgoKCkJiYqMz/119/YcKECXBzc4O1tTWaNWuGf//737hx44bZeq5fv46xY8fC0dER9vb2ePLJJ3HmzJlSt+/s2bMYOnQonJ2dYWNjA29vb4SFhVVo32g0Grz00ktYtWoVvLy8YGNjAx8fH3z99ddm/Yrey6ioKIwaNQp6vR52dna4ceMGTCYTFi5ciJYtWyrbPXz4cFy8eNFsGSKC9957D0ajEba2tujYsSN++uknBAQEICAgoMT2T5s2DU2bNoW1tTXc3NwwefLkEp+Fovq/+uoreHt7w87ODu3atcOWLVuUPvv27YNGo8H69etLbP+XX34JjUaDQ4cOlbmPirb9p59+wgsvvIBGjRpBp9Ohf//+OHfunFnf8j4f58+fR0hIiNn7tGjRIphMJrNlXLp0CcHBwXBwcECDBg0wePBgXL58uURdpe034NYpTE9PT7O2GzduYO7cufD29oatrS0cHR3Ro0cPxMbGKvsxOzsba9asgUajgUajUZZd1qmczZs3w8/PD3Z2dnBwcMATTzyBAwcOmPUpOu168uRJDBkyBA0aNICLiwtGjRqF//73v2Xuc7pPCJEKnD17VjQajUyePNms/eTJkwJA3njjDaUtPDxcAEhycrLS1r17d2nUqJG4u7vLsmXLZPfu3fLzzz+LiMg777wjixcvlh9//FH27NkjK1eulKZNm0qPHj3M1jVr1iypyJAYMWKEWFtbi4eHh8ybN0+ioqJk9uzZYmlpKf369TPrO2XKFFmxYoVs375ddu3aJYsXLxYnJyd54YUXzPqVVf/169elVatWotPpZO7cubJjxw7ZuHGjvPLKK7Jr1y4REcnNzZW2bduKTqeTDz/8UKKiomTmzJliaWkpQUFByjpMJpP06NFDbGxslLpnzZolzZo1EwAya9Yss/3eoEEDadOmjXz55ZcSFRUlU6dOFQsLC5k9e/Yd9xEAcXd3Fx8fH1m/fr1s3rxZnnzySQEg33zzjdKv6L10c3OTcePGybZt2+Tbb7+VgoICGTdunACQl156SbZv3y4rV64UvV4v7u7ukp6erizjzTffFAAybtw42b59u3z22Wfi4eEhBoNBunfvrvTLzs6W9u3bi5OTk3z00Ueyc+dOWbp0qTRo0EACAwPFZDKZ1e/p6SmdOnWSDRs2yNatWyUgIEAsLS0lKSlJ6fePf/xDunTpUmL7H330UXn00UfL3UdF2+7u7i6jRo2Sbdu2yaeffirOzs7i7u4u165dU/qW9fm4cuWKuLm5iV6vl5UrV8r27dvlpZdeEgASGhqqzJ+TkyPe3t7SoEEDWbZsmezYsUNefvll8fDwEAASHh5utq7b91uRESNGiNFoVF7n5+dLjx49xNLSUqZNmyZbt26VzZs3y4wZM2T9+vUiInLgwAHRarUSFBQkBw4ckAMHDsjJkydFRGT37t0CQHbv3q0sc+3atQJAevfuLZs2bZLIyEjp0KGDWFtby759+5R+RWO1RYsW8vbbb8tPP/0kH330kdjY2JQYW3T/YTAh1ejevbs4OTnJzZs3lbapU6cKADlz5ozSVlYwASDR0dHlrsNkMkl+fr78/PPPAkCOHTumTKtMMAEgS5cuNWufN2+eAJD9+/eXOl9hYaHk5+fLl19+KfXq1ZO//vrrjvXPnTtXAMhPP/1UZj0rV64UALJhwwaz9vfff18ASFRUlIiIbNu2rdy6bw8mffr0kSZNmsh///tfs74vvfSS2NramtVeGgCi1Wrl8uXLSltBQYG0bNlSHn74YaWt6L0cPny42fwJCQkCQCZMmGDWfvDgQQEgM2bMEBGRv/76S2xsbGTw4MFm/Q4cOCAAzH7Bzp8/XywsLOTQoUNmfb/99lsBIFu3bjWr38XFRa5fv660Xb58WSwsLGT+/Pkl6j969KjS9uuvvwoAWbNmTbn7qGjeAQMGmLXHxMQIAHn33XeVtrI+H2+88YYAkIMHD5q1h4aGikajkdOnT4uIyIoVKwSA/Oc//zHrN3bs2CoHky+//FIAyGeffVbudup0OhkxYkSJ9uLBpLCwUBo3bixt2rSRwsJCpd/ff/8tzs7O4u/vr7QVjdWFCxeaLXPChAlia2trFjLp/sNTOaQao0ePRkZGBjZv3gwAKCgoQEREBLp27YpHHnnkjvM3bNgQgYGBJdrPnTuHoUOHwtXVFfXq1YOVlRW6d+8OAEhISKhyvcOGDTN7PXToUADA7t27lbajR4/i6aefhqOjo7Lu4cOHo7CwsMQplNLq37ZtG7y8vNCrV68y69i1axd0Oh3+9a9/mbWPHDkSABAdHW1WV1l1F8nLy0N0dDQGDBgAOzs7FBQUKF9BQUHIy8vDL7/8UmY9RXr27AkXFxfldb169TB48GD8/vvvJU7HDBw40Ox1Ua1F21CkU6dO8Pb2Vrbpl19+wY0bNxAcHGzWr3PnziVOO2zZsgWtW7dG+/btzbapT58+pZ5S6NGjBxwcHJTXLi4ucHZ2RmpqqtI2ZMgQODs7m53iWrZsGfR6PQYPHlzO3vmf4u+Hv78/jEaj2ecIKP3zsWvXLvj4+KBTp05m7SNHjoSIYNeuXQBu7U8HBwc8/fTTZv2Kv/eVsW3bNtja2iqnlKrr9OnTuHTpEp5//nlYWPzvV5O9vT0GDhyIX375pcSp0uLb07ZtW+Tl5eHKlSs1UhPVDgYTUo1//etfaNCgAcLDwwEAW7duxZ9//qlc9Honpd2lk5WVha5du+LgwYN49913sWfPHhw6dAjfffcdgFsXWlaFpaUlHB0dzdpcXV0BAFevXgVw69x/165d8ccff2Dp0qXYt28fDh06pPwSK77u0upPT09HkyZNyq3l6tWrcHV1LXGrs7OzMywtLZV6rl69Wm7dty+voKAAy5Ytg5WVldlXUFAQACAjI6Pcmkpb7u1tRTUVKb7tRdNL2yeNGzc22yYAZgGoSPG2P//8E8ePHy+xTQ4ODhCREttUfD8BgI2Njdn7ZmNjg/Hjx2PdunXIzMxEeno6NmzYgDFjxtzx4uwiZe2nO+0j4Nb2l7WPiqYX/VvaPipt3RWVnp6Oxo0bm4WI6rjTe24ymXDt2jWz9uLvUdE+r+q4JnWwrO0CiIpotVoMGTIEn332GdLS0vDFF1/AwcEBgwYNqtD8pT2DZNeuXbh06RL27NmjHCUBUO4zUyqioKAAV69eNfvBWHQhYVHbpk2bkJ2dje+++w5Go1HpFx8fX+H69Xp9iaMLxTk6OuLgwYMQEbNlXLlyBQUFBXByclL6lVd3kYYNG6JevXp4/vnnMXHixFLX2bRp03JrKm25t7cV/4VSfNuLpqelpZUIZpcuXTLbJuBW6ChtXbcfNXFycoJWqy3z7q+iZVZWaGgoFixYgC+++AJ5eXkoKCjAiy++WOH5y9pPDz/8sFlbaZ8PR0dHpKWllWi/dOkSAJjtp19//bVC67a1tS31AtLiwU2v12P//v0wmUw1Ek5uf8+Lu3TpEiwsLNCwYcNqr4fUj0dMSFVGjx6NwsJCfPDBB9i6dSuee+452NnZVXl5RT/Mi//vddWqVdWqEwDWrl1r9rroOSxFdx2Utm4RwWeffVbhdfTt2xdnzpxRDsmXpmfPnsjKyirxrIgvv/xSmQ7cOjVRXt1F7Ozs0KNHDxw9ehRt27ZFx44dS3yVdjShuOjoaLPAUFhYiMjISDRv3vyOR4GKTllERESYtR86dAgJCQnKNj322GOwsbFBZGSkWb9ffvnF7JQLAPTr1w9JSUlwdHQsdZuKn/qpKIPBgEGDBuGTTz7BypUr0b9/f3h4eFR4/uLvR2xsLFJTU0u9M6a4nj174tSpUzhy5IhZe9FdQUXveY8ePfD3338rp0mLlPbsIE9PT5w5c8bsjq6rV68qd9oU6du3L/Ly8u74cLbiR5nK0qJFC7i5uWHdunVmt4tnZ2dj48aNyp069ODjERNSlY4dO6Jt27ZYsmQJRKTCp3HK4u/vj4YNG+LFF1/ErFmzYGVlhbVr1+LYsWPVWq61tTUWLVqErKwsPProo4iNjcW7776Lvn374vHHHwcAPPHEE7C2tsaQIUPw2muvIS8vDytWrChxOLo8kydPRmRkJJ555hm88cYb6NSpE3Jzc/Hzzz+jX79+6NGjB4YPH46wsDCMGDECKSkpaNOmDfbv34/33nsPQUFByvUpvXv3Rrdu3fDaa68hOzsbHTt2RExMDL766qsS6126dCkef/xxdO3aFaGhofD09MTff/+N33//HT/88EO5QamIk5MTAgMDMXPmTOh0OnzyySdITEwscctwaVq0aIFx48Zh2bJlsLCwQN++fZGSkoKZM2fC3d0dU6ZMAQA0atQIr776KubPn4+GDRtiwIABuHjxIubMmQODwWD2P/nJkydj48aN6NatG6ZMmYK2bdvCZDLh/PnziIqKwtSpU/HYY49V9K0x88orryjzFp2KrKjDhw9jzJgxGDRoEC5cuIB///vfcHNzw4QJE+4475QpU/Dll1/iqaeewty5c2E0GvHjjz/ik08+QWhoKLy8vAAAw4cPx+LFizF8+HDMmzcPjzzyCLZu3YodO3aUWObzzz+PVatWISQkBGPHjsXVq1excOHCEs8bGTJkCMLDw/Hiiy/i9OnT6NGjB0wmEw4ePAhvb28899xzAIA2bdpgz549+OGHH2AwGODg4IAWLVqUWK+FhQUWLlyIYcOGoV+/fhg/fjxu3LiBDz74AJmZmViwYEGl9ivdx2rzylui0ixdulQAiI+PT6nTy7orp1WrVqX2j42NFT8/P7GzsxO9Xi9jxoyRI0eOlLgboTJ35eh0Ojl+/LgEBASIVquVRo0aSWhoqGRlZZn1/eGHH6Rdu3Zia2srbm5uMn36dOXumNtvkyyv/mvXrskrr7wiHh4eYmVlJc7OzvLUU09JYmKi0ufq1avy4osvisFgEEtLSzEajfLmm29KXl6e2bIyMzNl1KhR8tBDD4mdnZ088cQTkpiYWOKuHBGR5ORkGTVqlLi5uYmVlZXo9Xrx9/c3u1ukLABk4sSJ8sknn0jz5s3FyspKWrZsKWvXrjXrV/ReFr9TRuTWXRrvv/++eHl5iZWVlTg5OUlISIhcuHDBrJ/JZJJ3331XmjRpItbW1tK2bVvZsmWLtGvXrsQdL1lZWfLWW29JixYtxNraWrklesqUKWZ3EBXVX5zRaCz1DhMREU9PT/H29r7jvim+7VFRUfL888/LQw89pNxae/bsWbO+5X0+UlNTZejQoeLo6ChWVlbSokUL+eCDD8zubBERuXjxogwcOFDs7e3FwcFBBg4cKLGxsSXGgYjImjVrxNvbW2xtbcXHx0ciIyNL3JUjcutW9bffflseeeQRsba2FkdHRwkMDJTY2FilT3x8vHTp0kXs7OzM7pQq7XZhEZFNmzbJY489Jra2tqLT6aRnz54SExNj1qdorN5+2/jt+/T2nw10/9GI8BGLRFSzNBoNJk6ciOXLl9fK+pOTk9GyZUvMmjULM2bMuOvrO378ONq1a4ewsLAKHekAbj1g7YUXXsChQ4fQsWPHu1wh0f2Dp3KI6L527NgxrF+/Hv7+/qhfvz5Onz6tnHqo7qnAO0lKSkJqaipmzJgBg8FQ4vZmIqo8BhMiuq/pdDocPnwYn3/+OTIzM9GgQQMEBARg3rx5pd4iW5Peeecd5bH133zzDS/OJKoBPJVDREREqsHbhYmIiEg1GEyIiIhINRhMiIiISDUYTIiIiEg1GEyIiIhINRhMiIiISDX4HJNKOn/+fIX+5DsR3RtOTk5l/tE8jlcidSlvvBZhMKmE8+fPw9vbGzk5ObVdChH9f3Z2dkhISCjxw47jlUh9yhqvt2MwqYSMjAzk5OQgIiIC3t7etV0OUZ2XkJCAkJAQZGRklPhBx/FKpC7ljdfbMZhUgbe3N3x9fWu7DCKqAI5XovsLL34lIiIi1WAwISIiItXgqRy6b129ehXjx4/HiRMn0L9/f2RnZ2PFihW1XRYRlYLjlSqKR0zovvXVV19Bp9MhMTERBoOhwvPFxsaiffv2JdpDQ0OxaNEis7b8/Hy0adMGQUFB1S2XqE6rznh1c3PDlClTzNo5Xh9cDCZ037pw4QJatGgBjUZz19axc+dOFBQU4MSJE0hMTLxr6yF60FVnvGq1WmzZsgVnz54ttx/H64OBwYTuS5MmTcK3336LTz/9FI888gi2bt2qTCvtiEi/fv0QGRlZ6fVERkZiwIAB8PPzq9L8RFT98Wpvb4+QkBC8//775a6H4/XBwGBC96Vly5ZhwIABGDduHM6ePXtXDt2mp6dj9+7dGDBgAAYOHIjvvvsO+fn5Nb4eogddTYzXSZMmYf/+/Th69Gip0zleHxwMJlQnZWRkwNvb2+xr27ZtZn02btwINzc3PProo3jqqaeQlZWFXbt21VLFRHVbo0aNMH78eMyfP7/U6RyvDw4GE6qTnJyckJCQYPbVt29fsz4bNmzAgAEDANw6lNynTx8eHiaqRePGjUNiYiL27t1bYhrH64ODtwvTA0en0yE3N9esLT09vVLLOHr0KE6fPo3Lly9j7dq1AIDc3Fzk5eUhIyMDTk5ONVYvUV1WmfGq0+nw8ssvY8GCBTAajUo7x+uDhUdM6IHTrFkzFBYWYuvWrSgoKMDq1atx+fLlSi0jMjISnTt3xp49exAVFYWoqCjs3bsXrq6u2Lhx412qnKjuqex4HT58OK5evYp9+/YpbRyvDxYGE3rgODg4YMGCBZg5cybatWuHK1euoE2bNhWePy8vD5s3b8bIkSPh7OysfLm4uGD48OHYsGHDXayeqG6p7Hi1trbGq6++imvXrgHgeH0QaUREaruI+8WRI0fQoUMHxMXF8Y+CEalAeWOS45VIXSo6JnnEhIiIiFSDwYSIiIhUg8GEiIiIVIO3C1dC0S1t8fHxtVsIEQEAEhISypzG8UqkLuWN19sxmFRCZmYmAGD06NG1WwgRKezs7Ep9TgXHK5H6lDVeb8dgUglFf6o7IiIC3t7etVwNEQG3nuLr4eFRop3jlUh9yhqvt2MwqQJvb2/efkh0n+B4Jbq/8OJXIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINPmDtLhk6dGiF+65bt+4uVkJERHT/4BETIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg3L2lz5li1bsGvXLqSkpMDPzw/Tp09Xpo0ZMwaZmZmwsLiVnfR6PcLCwpTpMTExWL16NTIzM+Ht7Y1XXnkFjo6OyvSIiAhs27YNJpMJXbt2xbhx42BpeWtzs7KyEBYWhiNHjkCr1SI4OBhBQUH3aKuJiIioLLUaTBo1aoTg4GDEx8fj77//LjH9zTffRIcOHUq0X7x4ER9//DHefPNNeHt7Izw8HB9++CHmz58PAIiKisLevXvx0UcfwdbWFu+88w42bNiAoUOHAgBWrVqFwsJChIeHIy0tDW+//TaaNGmCtm3b3t0NJiIionLV6qkcf39/dO7cGfXr16/UfLt374avry/at28PGxsbDBs2DImJiUhLSwMA7Ny5E88++yxcXFzQoEEDBAcHY+fOnQCAvLw8xMTEICQkBHZ2dmjevDkCAwOV6URERFR7avWIyZ0sWbIEIgIPDw+EhITAx8cHAJCamgovLy+ln4ODA/R6PVJTU2EwGHD+/Hl4enoq05s2bYqMjAxkZ2fj8uXLAAAPDw9lerNmzbBp06ZSa0hLS1MCT0JCQg1vIREREd1OtcHk1VdfRfPmzQEA0dHRmDNnDpYtWwZnZ2fk5eXBzs7OrL9Op0Nubi6AW0dFdDqd2TQAyM3NRV5eHrRabZnzFrdq1SrMmTOnxraLiIiIyqbau3J8fHxgY2MDGxsbBAUFoVmzZoiLiwMA2NraIicnx6x/dna2EjiKTy/6XqvVwtbWtkQIuX3e4saPH4+4uDjExcUhIiKixraPiIiISlLtEZPiLCwsICIAAKPRiJSUFGVaVlYWMjIyYDQaAdw6TZOcnAxvb28AQHJyMpycnKDT6eDm5gYAuHDhAtzd3ZXpRfMWZzAYYDAY7tZmERER0W1q9YhJYWEhbt68CZPJBJPJhJs3b6KgoADp6ek4efIk8vPzkZ+fjx07duDs2bP4xz/+AQAICAhAXFwcjh07hhs3bmDt2rVo0aKFEiB69uyJzZs348qVK7h+/ToiIyPRq1cvALeOpnTp0gVr165FTk4OkpOTER0djZ49e9bafiAiIqJbavWISWRkJL7++mvldUxMDAIDA/HPf/4Tn376KdLS0mBpaQl3d3fMnDlTCR7u7u6YNGkSli9fjmvXrsHHxwfTpk1TltO7d2+kp6djypQpKCwsRLdu3RAcHKxMHz9+PJYvX46RI0fCzs4Ow4YNQ7t27e7dhhMREVGpNFJ0foTu6MiRI+jQoQPi4uLg6+tbbt+iZ6ZUxLp166pbGhEVU5nxSkTqodqLX4mIiKjuYTAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItVgMCEiIiLVYDAhIiIi1WAwISIiItWoUjAJDAxEZmZmifbr168jMDCwujURERFRHVWlYLJnzx7cvHmzRHteXh727dtX7aKIiIiobrKsTOfjx48r3586dQqXL19WXhcWFmL79u1wc3OrueqIiIioTqlUMGnfvj00Gg00Gk2pp2y0Wi2WLVtW4eVt2bIFu3btQkpKCvz8/DB9+nRlWmpqKpYtW4aUlBS4uroiNDQUrVq1UqbHxMRg9erVyMzMhLe3N1555RU4Ojoq0yMiIrBt2zaYTCZ07doV48aNg6Xlrc3NyspCWFgYjhw5Aq1Wi+DgYAQFBVVmVxAREdFdUKlTOcnJyUhKSoKI4Ndff0VycrLy9ccff+D69esYNWpUhZfXqFEjBAcHo3fv3mbtBQUFePfdd+Hn54f169dj4MCBmDdvHrKysgAAFy9exMcff4yJEyciIiICjRs3xocffqjMHxUVhb179+Kjjz7CypUrce7cOWzYsEGZvmrVKhQWFiI8PBwzZ87E2rVrzY4GERERUe2oVDAxGo3w9PSEyWRCx44dYTQalS+DwYB69epVauX+/v7o3Lkz6tevb9Z+4sQJ3LhxAwMGDICVlRV69OgBFxcXxMbGAgB2794NX19ftG/fHjY2Nhg2bBgSExORlpYGANi5cyeeffZZuLi4oEGDBggODsbOnTsB3LoOJiYmBiEhIbCzs0Pz5s0RGBioTCciIqLaU6lTObc7c+YM9uzZgytXrsBkMplNe/vtt6tV1Pnz52E0GmFh8b/c1LRpU5w/fx7ArdM8Xl5eyjQHBwfo9XqkpqbCYDDg/Pnz8PT0NJs3IyMD2dnZynUxHh4eyvRmzZph06ZNpdaSlpamBJ6EhIRqbRcRERGVr0rB5LPPPkNoaCicnJzg6uoKjUajTNNoNNUOJrm5udDpdGZtOp0OOTk5AG4d9bCzsysxPTc3V5l++/xF3+fm5iIvLw9arbbMeYtbtWoV5syZU63tISIiooqpUjB59913MW/ePLz++us1XQ+AWxfRFoWQIjk5OUqgsLW1LTE9Ozu7zOlF32u1Wtja2pYIIbfPW9z48ePx9NNPA7h1xCQkJKQaW0ZE97uhQ4dWqN+6devuciVED6YqPcfk2rVrGDRoUE3XovDw8EBqaqrZKaLk5GTl9IvRaERKSooyLSsrCxkZGTAajcr8ycnJZvM6OTlBp9MptzNfuHDBbHrRvMUZDAb4+vrC19cX3t7eNbaNREREVFKVgsmgQYMQFRVV7ZUXFhbi5s2bMJlMMJlMuHnzJgoKCtCmTRtYWVlh06ZNyM/Px88//4zLly/Dz88PABAQEIC4uDgcO3YMN27cwNq1a9GiRQsYDAYAQM+ePbF582ZcuXIF169fR2RkJHr16gXg1tGULl26YO3atcjJyUFycjKio6PRs2fPam8PERERVU+VTuU8/PDDmDlzJn755RclRNzu5ZdfrtByIiMj8fXXXyuvY2JiEBgYiMmTJ+Ott97C8uXLsW7dOri4uGDGjBlwcHAAALi7u2PSpElYvnw5rl27Bh8fH0ybNk1ZTu/evZGeno4pU6agsLAQ3bp1Q3BwsDJ9/PjxWL58OUaOHAk7OzsMGzYM7dq1q8quIKIHQEVPzxDR3acREansTE2bNi17gRoNzp07V62i1OrIkSPo0KED4uLi4OvrW27fyvyg47loopp3t8ZrRXFcE1VNlY6Y3H79BhEREVFNqdI1JkRERER3Q5WOmNzpsfNffPFFlYohIiKiuq1KweTatWtmr/Pz8/Hbb78hMzOz1D/uR0RERFQRVQom33//fYk2k8mECRMmoFmzZtUuioiIiOqmGrvGxMLCAlOmTMHixYtrapFERERUx9Toxa9JSUkoKCioyUUSERFRHVKlUzmvvvqq2WsRQVpaGn788UeMGDGiRgojIiKiuqdKweTo0aNmry0sLKDX67Fo0aI73rFDREREVJYqBZPdu3fXdB1EREREVQsmRdLT03H69GloNBp4eXlBr9fXVF1ERERUB1Xp4tfs7GyMGjUKBoMB3bp1Q9euXdG4cWOMHj0aOTk5NV0jERER1RFVCiavvvoqfv75Z/zwww/IzMxEZmYm/vOf/+Dnn3/G1KlTa7pGIiIiqiOqdCpn48aN+PbbbxEQEKC0BQUFQavVIjg4GCtWrKip+oiIiKgOqdIRk5ycHLi4uJRod3Z25qkcIiIiqrIqBRM/Pz/MmjULeXl5Sltubi7mzJkDPz+/GiuOiIiI6pYqncpZsmQJ+vbtiyZNmqBdu3bQaDSIj4+HjY0NoqKiarpGIiIiqiOqFEzatGmDs2fPIiIiAomJiRARPPfccxg2bBi0Wm1N10hERER1RJWCyfz58+Hi4oKxY8eatX/xxRdIT0/H66+/XiPFERERUd1SpWtMVq1ahZYtW5Zob9WqFVauXFntooiIiKhuqlIwuXz5MgwGQ4l2vV6PtLS0ahdFREREdVOVgom7uztiYmJKtMfExKBx48bVLoqIiIjqpipdYzJmzBhMnjwZ+fn5CAwMBABER0fjtdde45NfiYiIqMqqFExee+01/PXXX5gwYQJu3rwJALC1tcXrr7+ON998s0YLJCIiorqjSsFEo9Hg/fffx8yZM5GQkACtVotHHnkENjY2NV0fERER1SFVCiZF7O3t8eijj9ZULURERFTHVeniVyIiIqK7gcGEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFTDsrYLKM+SJUuwd+9eWFr+r8ywsDDo9XoAQGpqKpYtW4aUlBS4uroiNDQUrVq1UvrGxMRg9erVyMzMhLe3N1555RU4Ojoq0yMiIrBt2zaYTCZ07doV48aNM1sXERER3VuqP2LyzDPPYMOGDcpXUSgpKCjAu+++Cz8/P6xfvx4DBw7EvHnzkJWVBQC4ePEiPv74Y0ycOBERERFo3LgxPvzwQ2W5UVFR2Lt3Lz766COsXLkS586dw4YNG2plG4mIiOgW1QeTspw4cQI3btzAgAEDYGVlhR49esDFxQWxsbEAgN27d8PX1xft27eHjY0Nhg0bhsTERKSlpQEAdu7ciWeffRYuLi5o0KABgoODsXPnztrcJCIiojpP9ectduzYgR07dsDJyQn9+/fHE088AQA4f/48jEYjLCz+l62aNm2K8+fPA7h1msfLy0uZ5uDgAL1ej9TUVBgMBpw/fx6enp5m82ZkZCA7Oxs6ne7ebNz/N3To0Ar1W7du3V2uhIiIqHapOpj0798fo0aNgk6nw6lTp7BgwQLodDr4+/sjNze3RIDQ6XTIyckBAOTl5cHOzq7E9NzcXGX67fMXfV98uWlpacpRloSEhJrfSCIiIlKoOpg0b95c+b5NmzZ46qmnEBMTA39/f2i1WiWEFMnJyYFWqwUA2NralpienZ1d5vSi74umF1m1ahXmzJlTcxtFREREZbqvrjHRaDQQEQCAh4cHUlNTYTKZlOnJycnw8PAAABiNRqSkpCjTsrKykJGRAaPRqMyfnJxsNq+Tk1OJozDjx49HXFwc4uLiEBERcbc2jYiIiKDyYLJ//37k5OTAZDLh1KlT+PHHH9G5c2cAt46gWFlZYdOmTcjPz8fPP/+My5cvw8/PDwAQEBCAuLg4HDt2DDdu3MDatWvRokULGAwGAEDPnj2xefNmXLlyBdevX0dkZCR69epVogaDwQBfX1/4+vrC29v73m08ERFRHaTqUzlbtmxBWFgYTCYTnJycMGzYMHTr1g0AYGlpibfeegvLly/HunXr4OLighkzZsDBwQEA4O7ujkmTJmH58uW4du0afHx8MG3aNGXZvXv3Rnp6OqZMmYLCwkJ069YNwcHBtbKdREREdIuqg8mCBQvKne7p6Wn2bJLiHn/8cTz++OOlTtNoNAgJCUFISEi1aiQiIqKao+pTOURERFS3MJgQERGRajCYEBERkWowmBAREZFqMJgQERGRajCYEBERkWowmBAREZFqMJgQERGRajCYEBERkWowmBAREZFqMJgQERGRaqj6b+UQEd2vhg4dWqF+69atu8uVEN1feMSEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDwYSIiIhUg8GEiIiIVIPBhIiIiFSDD1i7j/CBTURE9KDjERMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlIN/hE/IqJaVNE/zgnwD3RS3cAjJkRERKQaDCZERESkGgwmREREpBoMJkRERKQaDCZERESkGrwrh4iIqAy8a+re4xETIiIiUg0eMXkAMeETEdH9ikdMiIiISDUYTIiIiEg1eCqHqIZU9BQaT58REZWNR0yIiIhINXjEhIjoPsGjclQXMJgQ3WO8a4qIqGx1OphkZWUhLCwMR44cgVarRXBwMIKCgmq7rHuK/wNTN74/RFTX1OlgsmrVKhQWFiI8PBxpaWl4++230aRJE7Rt27a2SyOqFB6FIap9lRmHFVUXx2udvfg1Ly8PMTExCAkJgZ2dHZo3b47AwEDs3LmztksjIiKqs+rsEZM//vgDAODh4aG0NWvWDJs2baqliojuDZ4eevDxCNqDoy6O1zobTPLy8qDVas3adDodcnNzzdrS0tKQlpYGAEhISLhn9anN3ThESerGw9J1A8f2g6E238eaHtd1NpjY2tqWCCHZ2dklwsqqVaswZ86cSi+fP4CJ7h8cr0TqUWevMXFzcwMAXLhwQWlLTk6G0Wg06zd+/HjExcUhLi4OERER97RGIiKiuqbOBhNbW1t06dIFa9euRU5ODpKTkxEdHY2ePXua9TMYDPD19YWvry+8vb1rqVoiIqK6oc6eygFuHQ1Zvnw5Ro4cCTs7OwwbNgzt2rWr7bKIiIjqrDodTOzt7fHGG2/UdhlERET0/9XZUzlERESkPgwmREREpBoMJkRERKQaDCZERESkGnX64tfKKnogW11+AiyRGrVs2RJ2dnZmbRyvROpU2ni9HYNJJaSkpAAAQkJCarcQIjITFxcHX19fszaOVyJ1Km283k4jInIP67mvZWRkYMeOHfD09Czx6Ho1SEhIQEhICCIiIlT7MDjWWDNYo7nS/gfG8Vp9rLFmsEZzPGJSg5ycnDBs2LDaLuOOvL29y02jasAaawZrLBvHa81hjTWDNVYML34lIiIi1WAweYAYDAbMmjULBoOhtkspE2usGazx/nc/7B/WWDNYY+XwGhMiIiJSDR4xISIiItVgMCEiIiLVYDAhIiIi1eDtwiq3ZcsW7Nq1CykpKfDz88P06dOrvCyTyYTIyEj89NNPyMrKgl6vx1tvvVXti51qssYxY8YgMzMTFha3MrNer0dYWFi16qvpGoucOHEC//73vzFw4ECMGDFCNTXm5uZizpw5uHDhAgoKCuDq6oohQ4agc+fOqqnxjz/+wOrVq5GYmIiCggIYjUaMHj0ajzzySLVrrE0crxyvlcXxWhKDico1atQIwcHBiI+Px99//12tZX399dc4ceIE3nvvPbi4uODSpUtwcHBQVY0A8Oabb6JDhw7VXs7tarrG/Px8fPbZZ2jZsmUNVHdLTdVoZWWFCRMmwM3NDfXq1UNCQgJmz56NTz75BI6OjqqoMTs7Gx06dMCkSZOg0+mwbds2zJkzB//3f/8HW1vbatVYmzheawbHa90erwwmKufv7w8AOHfuXIkP1tmzZ/H5558jNTUVDRs2REhIiNK/uKysLGzatAlLliyBq6srAMDNzU1VNd5NNV3jN998g06dOiEjI0N1NVpaWsLDwwMAICLQaDQoKCjAlStXqv2DrqZq9PLygpeXl/K6X79+WL16NS5evIiHH364WjXWJo7XmsHxWrfHK4PJfeqvv/7C7NmzMWnSJDz66KP4/fffMWfOHLi7u8Pd3b1E/9TUVNSrVw+xsbHYvHkzbG1tERgYiMGDB0Oj0aiixiJLliyBiMDDwwMhISHw8fG5K/VVtcY//vgD+/btw5IlS7BixYq7Vlt1agSAN954A2fOnEFBQQHatWtn9oNFLTUWOXv2LEREFc9QuBs4XmuvRo7XmquxyN0er7z49T61e/dutGvXDp07d0a9evXQokULdO7cGTExMaX2z8jIQHZ2Ni5cuIBPP/0Us2bNws6dOxEdHa2aGgHg1Vdfxf/93//h888/x+OPP445c+bgypUrqqrxk08+wQsvvAAbG5u7Vld1awSABQsWIDIyEjNmzECHDh1Qr1491dUIANevX8dHH32EYcOGQafT3bUaaxPHa+3VyPFaczUC92a88ojJferKlSs4ePAghgwZorQVFhYiICAA6enpmDhxotIeFhamDMrnnnsOtra2cHNzQ+/evXH48GH06tVLFTXq9Xqz/20FBQVh3759iIuLQ9++fVVR44kTJ6DVatGpU6e7Uk9N1KjX65XXVlZW6Ny5M9566y00btz4rtVd1Rqzs7MxZ84c+Pr64p///OddqU0NOF5rp0aO15qt8V6NVwaT+5Rer0fXrl0xefLkUqdv2LDB7HVhYSEA3LXDwKWpbI2lsbCwwN18OHFlazx+/DhOnDih/HG4vLw8aDQanDlzBvPmzVNFjaUpLCxEWlpaDVf2P1WpMScnB7NmzULz5s0xduzYu1abGnC81gyO15qh9vHKUzkqV1hYiJs3b8JkMsFkMuHmzZsoKChAQEAA4uLi8Ouvv6KwsBD5+fk4ffo0Lly4UOpyXF1d0aZNG0RGRuLmzZu4fPkyoqKi8Nhjj6mmxvT0dJw8eRL5+fnIz8/Hjh07cPbsWfzjH/9QTY1jxoxBWFgYli5diqVLl6JTp07o1atXjdzOWFM1JiUl4fjx48p+jIqKwunTp9G6dWvV1Fj0Q87d3R2hoaHVrkstOF45Xjleq49/K0fl1q1bh6+//tqsLTAwEJMnT8bZs2exZs0aJCcnAwA8PT0xevRoNGvWrNRl/fXXX1i+fDl+++032NvbIygoCP/6179UU+P58+exaNEipKWlwdLSEu7u7ggJCUGbNm1UU2NxS5YsQcOGDWvkuQg1VePp06excuVKXLp0CRYWFnBzc8OgQYNq5JdaTdUYHR2NpUuXwsbGxuyowKxZs9CqVatq11lbOF45Xjleq4/BhIiIiFSDp3KIiIhINRhMiIiISDUYTIiIiEg1GEyIiIhINRhMiIiISDUYTIiIiEg1GEyIiIhINRhMiIiISDUYTOi+IyIYN24cGjVqBI1Gg/j4+Hu6/j179kCj0SAzM/Oerrc0MTExaNOmDaysrPDss8/WdjkAgICAgDL/Bkdt8PT0xJIlS6o07+zZs9G+ffsarYeIysdgQved7du3Y/Xq1diyZQvS0tJq5G9KlKW0X7L+/v5IS0tDgwYN7tp6K+rVV19F+/btkZycjNWrV5fap6q/mKvzC/1BMW3aNERHR9d2Gaq2evVqPPTQQ3dl2QyGdRODCd13kpKSYDAY4O/vD1dXV1halvwj2Tdv3rxr67e2toarq+s9/cuvZUlKSkJgYCCaNGly13453G35+fm1XUKZ7O3t4ejoWNtl1DgRQUFBQW2XQVQ6IbqPjBgxQgAoX0ajUUREunfvLhMnTpQpU6aIo6OjdOvWTUREFi1aJK1btxY7Oztp0qSJhIaGyt9//222zP3790u3bt1Eq9XKQw89JL1795a//vqrxLoASHJysuzevVsAyLVr15RlfPvtt+Lj4yPW1tZiNBrlww8/NFuH0WiUefPmyQsvvCD29vbi7u4uq1atKndb8/LyZNKkSaLX68XGxka6dOkiv/76q4iIJCcnl6gtPDy8xDK6d+9eol9Fai5rvoyMDHnuuefEzc1NtFqttG7dWtatW1dina+88kqZ2zVr1ixp166dfP7559K0aVPRaDRiMpkkMzNTxo4dK3q9XhwcHKRHjx4SHx+vzPf777/L008/Lc7OzqLT6aRjx47y008/mS37zz//lH79+omtra14enpKRESEGI1GWbx4sdn63d3dxdraWgwGg0yaNOmOtRYZMWKEPPPMM/LBBx+Iq6urNGrUSCZMmCA3b94scxnx8fESEBAg9vb24uDgIL6+vnLo0KFSly8isnjxYuVzffs6Z8+ereybcePGyY0bN5Q+JpNJ3n//fWnatKnY2tpK27Zt5ZtvvlGmF31mt2/fLh06dBArKyvZtWuXdO/eXSZNmiTTp0+Xhg0biouLi8yaNcusnvLGUNFyb/8qmv+rr76SDh06iL29vbi4uMiQIUPkzz//LFHTzp07pUOHDqLVasXPz08SExNFRCQ8PLxCn3F68DCY0H0lMzNT5s6dK02aNJG0tDS5cuWKiNz6ZWhvby/Tp0+XxMRESUhIEJFbP+R37dol586dk+joaGnRooWEhoYqyzt69KjY2NhIaGioxMfHy2+//SbLli2T9PR0yczMFD8/Pxk7dqykpaVJWlqaFBQUlAgmhw8fFgsLC5k7d66cPn1awsPDRavVmv0QNRqN0qhRIwkLC5OzZ8/K/PnzxcLCQqmzNC+//LI0btxYtm7dKidPnpQRI0ZIw4YN5erVq1JQUCBpaWlSv359WbJkiaSlpUlOTk6JZVy9elWaNGkic+fOVbahIjWXNd/Fixflgw8+kKNHj0pSUpJ8/PHHUq9ePfnll1+UdVYkmOh0OunTp48cOXJEjh07JiaTSbp06SL9+/eXQ4cOyZkzZ2Tq1Kni6OgoV69eFZFbv+BXrlwpx48flzNnzsi///1vsbW1ldTUVGXZffv2ldatW0tsbKwcPnxY/P39RavVKsHkm2++kfr168vWrVslNTVVDh48KJ9++mm5tRYPJvXr15cXX3xREhIS5IcffhA7O7tyl9GqVSsJCQmRhIQEOXPmjGzYsEEJXBUNJvb29jJ48GD57bffZMuWLaLX62XGjBlKnxkzZkjLli1l+/btkpSUJOHh4WJjYyN79uwRkf+FgLZt20pUVJT8/vvvkpGRId27d5f69evL7Nmz5cyZM7JmzRrRaDQSFRVlVk9ZY+jGjRuyZMkSqV+/vvI5KQotn3/+uWzdulWSkpLkwIED0rlzZ+nbt6+y3KKaHnvsMdmzZ4+cPHlSunbtKv7+/iIikpOTI1OnTpVWrVopyy7tM04PHgYTuu8U/8EtcuuXYfv27e8474YNG8TR0VF5PWTIEOnSpUuZ/Uv7JVs8mAwdOlSeeOIJsz7Tp08XHx8f5bXRaJSQkBDltclkEmdnZ1mxYkWp683KyhIrKytZu3at0nbz5k1p3LixLFy4UGlr0KDBHf8XWfyIQWVqLj5faYKCgmTq1KnK64oEEysrKyVUiohER0dL/fr1JS8vz6xv8+bNyz2y5OPjI8uWLRMRkdOnTwsAs5CUkJAgAJTtWLRokXh5eZV7hKN4rcWDidFolIKCAqVt0KBBMnjw4DKX4eDgIKtXr67Q8kVKDyaNGjWS7OxspW3FihVib28vhYWFkpWVJba2thIbG2u2nNGjR8uQIUNE5H+f2U2bNpn16d69uzz++ONmbY8++qi8/vrrZW5P8TEUHh4uDRo0KLN/kV9//VUAlDjasnPnTqXPjz/+KAAkNzdXRErfP/Tg4zUm9MDo2LFjibbdu3fjiSeegJubGxwcHDB8+HBcvXoV2dnZAID4+Hj07NmzWutNSEhAly5dzNq6dOmCs2fPorCwUGlr27at8r1Go4GrqyuuXLlS6jKTkpKQn59vtlwrKyt06tQJCQkJ1aq3MjUXV1hYiHnz5qFt27ZwdHSEvb09oqKicP78+Uqt32g0Qq/XK6/j4uKQlZWlLLPoKzk5GUlJSQCA7OxsvPbaa/Dx8cFDDz0Ee3t7JCYmKutOSEiApaWl2eegZcuWZtfeDBo0CLm5uWjWrBnGjh2L77//vtLXWrRq1Qr16tVTXhsMhjLfR+DWBcpjxoxBr169sGDBAmV7KqNdu3aws7NTXvv5+SErKwsXLlzAqVOnkJeXhyeeeMJs33355Zcl1lXaGLn9c1na9txpDJXl6NGjeOaZZ2A0GuHg4ICAgAAAKPFZuX39BoMBAMrdn/TgYzChB4ZOpzN7nZqaiqCgILRu3RobN25EXFwcwsLCAPzvgkutVlvt9YpIiQthRaREPysrK7PXGo0GJpOpzGUW9bnTuqqiojUXt2jRIixevBivvfYadu3ahfj4ePTp06fSFxsXf69MJhMMBgPi4+PNvk6fPo3p06cDAKZPn46NGzdi3rx52LdvH+Lj49GmTRtl3WXts9u5u7vj9OnTCAsLg1arxYQJE9CtW7dKXYBbmfcRuHVnycmTJ/HUU09h165d8PHxwffffw8AsLCwKLHfK1PL7ev+8ccfzfbdqVOn8O2335r1L77f77Q9FRlDpcnOzkbv3r1hb2+PiIgIHDp0SNnm4p+V29df9N6Vtz/pwVfydgaiB8Thw4dRUFCARYsWwcLiVgbfsGGDWZ+2bdsiOjoac+bMKXUZ1tbW5R5BAAAfHx/s37/frC02NhZeXl5m/7OujIcffhjW1tbYv38/hg4dCuDWL4LDhw9X+hkhpW1DRWoubb59+/bhmWeeQUhICIBbv0DOnj0Lb2/vStVUnK+vLy5fvgxLS0t4enqW2mffvn0YOXIkBgwYAADIyspCSkqKMt3b2xsFBQU4fPgwOnXqBAA4ffp0iefNaLVaPP3003j66acxceJEtGzZEidOnICvr2+1tqE8Xl5e8PLywpQpUzBkyBCEh4djwIAB0Ov1uHz5sllQLO25PMeOHUNubq4SpH/55RfY29ujSZMmaNiwIWxsbHD+/Hl07969RuuuyBgq7XOSmJiIjIwMLFiwAO7u7sqyKqsi448ePDxiQg+s5s2bo6CgAMuWLcO5c+fw1VdfYeXKlWZ93nzzTRw6dAgTJkzA8ePHkZiYiBUrViAjIwPArWd5HDx4ECkpKcjIyCj1f3JTp05FdHQ03nnnHZw5cwZr1qzB8uXLMW3atCrXrtPpEBoaiunTp2P79u04deoUxo4di5ycHIwePbpSy/L09MTevXvxxx9/KNtVkZpLm+/hhx/GTz/9hNjYWCQkJGD8+PG4fPlylbezSK9eveDn54dnn30WO3bsQEpKCmJjY/HWW28pv9AefvhhfPfdd4iPj8exY8cwdOhQs/ejRYsWePLJJzF27FgcPHgQcXFxGDNmjNlRsdWrV+Pzzz/Hb7/9pnwmtFotjEZjtbehNLm5uXjppZewZ88epKamIiYmBocOHVKCXEBAANLT07Fw4UIkJSUhLCwM27ZtK7GcmzdvYvTo0Th16hS2bduGWbNm4aWXXoKFhQUcHBwwbdo0TJkyBWvWrEFSUhKOHj2KsLAwrFmzplr1V2QMeXp6IisrC9HR0cjIyEBOTg48PDxgbW2tzLd582a88847lV6/p6cnkpOTER8fj4yMDNy4caNa20P3BwYTemC1b98eH330Ed5//320bt0aa9euxfz58836eHl5ISoqCseOHUOnTp3g5+eH//znP8qzUaZNm4Z69erBx8cHer2+1GspfH19sWHDBnz99ddo3bo13n77bcydOxcjR46sVv0LFizAwIED8fzzz8PX1xe///47duzYgYYNG1ZqOXPnzkVKSgqaN2+uXNdRkZpLm2/mzJnw9fVFnz59EBAQAFdX1xp54qxGo8HWrVvRrVs3jBo1Cl5eXnjuueeQkpICFxcXAMDixYvRsGFD+Pv7o3///ujTp0+Joxzh4eFwd3dH9+7d8c9//hPjxo2Ds7OzMv2hhx7CZ599hi5duihHy3744Ye79qySevXq4erVqxg+fDi8vLwQHByMvn37KkfovL298cknnyAsLAzt2rXDr7/+Wmqg7dmzJx555BF069YNwcHB6N+/P2bPnq1Mf+edd/D2229j/vz58Pb2Rp8+ffDDDz+gadOm1aq/ImPI398fL774IgYPHgy9Xo+FCxdCr9dj9erV+Oabb+Dj44MFCxbgww8/rPT6Bw4ciCeffBI9evSAXq/H+vXrq7U9dH/QSEVOLBMRUa0YOXIkMjMzsWnTptouheie4BETIiIiUg0GEyIiIlINnsohIiIi1eAREyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSDQYTIiIiUg0GEyIiIlINBhMiIiJSjf8HkvxcqxuNHx8AAAAASUVORK5CYII=\n",
@@ -1104,7 +1380,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776402446532)>"
+       "<ggplot: (8783978544159)>"
       ]
      },
      "metadata": {},
@@ -1136,7 +1412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -1159,7 +1435,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776403668110)>"
+       "<ggplot: (8783972753749)>"
       ]
      },
      "metadata": {},
@@ -1194,7 +1470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -1233,7 +1509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -1256,7 +1532,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776398840068)>"
+       "<ggplot: (8783972900380)>"
       ]
      },
      "metadata": {},
@@ -1293,7 +1569,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -1316,7 +1592,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776398841348)>"
+       "<ggplot: (8783969241257)>"
       ]
      },
      "metadata": {},
@@ -1353,7 +1629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {
     "scrolled": true
    },
@@ -1378,7 +1654,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776402456149)>"
+       "<ggplot: (8783949253623)>"
       ]
      },
      "metadata": {},
@@ -1417,7 +1693,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1468,7 +1744,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1483,7 +1759,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1498,7 +1774,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1513,7 +1789,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1528,7 +1804,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1654,11 +1930,11 @@
        "66336  TTTTTTTACTCAGAAT            NaN                 NaN               NaN   \n",
        "\n",
        "       sup_count  freq_progeny  in_infected_cell  \n",
-       "0            NaN           NaN             False  \n",
-       "1            NaN           NaN             False  \n",
-       "2            NaN           NaN             False  \n",
-       "3            NaN           NaN             False  \n",
-       "4            NaN           NaN             False  \n",
+       "0            NaN  0.000000e+00             False  \n",
+       "1            NaN  0.000000e+00             False  \n",
+       "2            NaN  0.000000e+00             False  \n",
+       "3            NaN  0.000000e+00             False  \n",
+       "4            NaN  0.000000e+00             False  \n",
        "...          ...           ...               ...  \n",
        "66332        1.0  4.799773e-07             False  \n",
        "66333        1.0  4.799773e-07             False  \n",
@@ -1669,7 +1945,7 @@
        "[66337 rows x 12 columns]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1695,7 +1971,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -1718,7 +1994,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776402331380)>"
+       "<ggplot: (8783972863651)>"
       ]
      },
      "metadata": {},
@@ -1759,7 +2035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -1811,7 +2087,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
@@ -1827,7 +2103,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
@@ -1843,7 +2119,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
@@ -1859,7 +2135,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
@@ -1875,7 +2151,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
@@ -2008,11 +2284,11 @@
        "66336  TTTTTTTACTCAGAAT            NaN                 NaN               NaN   \n",
        "\n",
        "       sup_count  freq_progeny  in_infected_cell  n_cell_bc  \n",
-       "0            NaN           NaN             False        NaN  \n",
-       "1            NaN           NaN             False        NaN  \n",
-       "2            NaN           NaN             False        NaN  \n",
-       "3            NaN           NaN             False        NaN  \n",
-       "4            NaN           NaN             False        NaN  \n",
+       "0            NaN  0.000000e+00             False        NaN  \n",
+       "1            NaN  0.000000e+00             False        NaN  \n",
+       "2            NaN  0.000000e+00             False        NaN  \n",
+       "3            NaN  0.000000e+00             False        NaN  \n",
+       "4            NaN  0.000000e+00             False        NaN  \n",
        "...          ...           ...               ...        ...  \n",
        "66332        1.0  4.799773e-07             False        NaN  \n",
        "66333        1.0  4.799773e-07             False        NaN  \n",
@@ -2023,7 +2299,7 @@
        "[66337 rows x 13 columns]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2065,7 +2341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -2081,7 +2357,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776398449737)>"
+       "<ggplot: (8783969241134)>"
       ]
      },
      "metadata": {},
@@ -2117,7 +2393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -2170,7 +2446,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -2187,7 +2463,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -2204,7 +2480,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -2221,7 +2497,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -2238,7 +2514,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -2378,11 +2654,11 @@
        "66336  TTTTTTTACTCAGAAT            NaN                 NaN               NaN   \n",
        "\n",
        "       sup_count  freq_progeny  in_infected_cell  n_cell_bc  gt1_cell  \n",
-       "0            NaN           NaN             False        NaN     False  \n",
-       "1            NaN           NaN             False        NaN     False  \n",
-       "2            NaN           NaN             False        NaN     False  \n",
-       "3            NaN           NaN             False        NaN     False  \n",
-       "4            NaN           NaN             False        NaN     False  \n",
+       "0            NaN  0.000000e+00             False        NaN     False  \n",
+       "1            NaN  0.000000e+00             False        NaN     False  \n",
+       "2            NaN  0.000000e+00             False        NaN     False  \n",
+       "3            NaN  0.000000e+00             False        NaN     False  \n",
+       "4            NaN  0.000000e+00             False        NaN     False  \n",
        "...          ...           ...               ...        ...       ...  \n",
        "66332        1.0  4.799773e-07             False        NaN     False  \n",
        "66333        1.0  4.799773e-07             False        NaN     False  \n",
@@ -2393,7 +2669,7 @@
        "[66337 rows x 14 columns]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2414,7 +2690,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -2430,7 +2706,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776390563431)>"
+       "<ggplot: (8783949253401)>"
       ]
      },
      "metadata": {},
@@ -2466,7 +2742,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -2489,7 +2765,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776402271585)>"
+       "<ggplot: (8783947951234)>"
       ]
      },
      "metadata": {},
@@ -2529,7 +2805,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -2583,7 +2859,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -2601,7 +2877,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -2619,7 +2895,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -2637,7 +2913,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -2655,7 +2931,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -2802,11 +3078,11 @@
        "66336  TTTTTTTACTCAGAAT            NaN                 NaN               NaN   \n",
        "\n",
        "       sup_count  freq_progeny  in_infected_cell  n_cell_bc  gt1_cell  \\\n",
-       "0            NaN           NaN             False        NaN     False   \n",
-       "1            NaN           NaN             False        NaN     False   \n",
-       "2            NaN           NaN             False        NaN     False   \n",
-       "3            NaN           NaN             False        NaN     False   \n",
-       "4            NaN           NaN             False        NaN     False   \n",
+       "0            NaN  0.000000e+00             False        NaN     False   \n",
+       "1            NaN  0.000000e+00             False        NaN     False   \n",
+       "2            NaN  0.000000e+00             False        NaN     False   \n",
+       "3            NaN  0.000000e+00             False        NaN     False   \n",
+       "4            NaN  0.000000e+00             False        NaN     False   \n",
        "...          ...           ...               ...        ...       ...   \n",
        "66332        1.0  4.799773e-07             False        NaN     False   \n",
        "66333        1.0  4.799773e-07             False        NaN     False   \n",
@@ -2830,7 +3106,7 @@
        "[66337 rows x 15 columns]"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2870,7 +3146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -2886,7 +3162,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776389743044)>"
+       "<ggplot: (8783949738572)>"
       ]
      },
      "metadata": {},
@@ -2923,7 +3199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -2978,7 +3254,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -2997,7 +3273,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -3016,7 +3292,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -3035,7 +3311,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -3054,7 +3330,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -3208,11 +3484,11 @@
        "66336  TTTTTTTACTCAGAAT            NaN                 NaN               NaN   \n",
        "\n",
        "       sup_count  freq_progeny  in_infected_cell  n_cell_bc  gt1_cell  \\\n",
-       "0            NaN           NaN             False        NaN     False   \n",
-       "1            NaN           NaN             False        NaN     False   \n",
-       "2            NaN           NaN             False        NaN     False   \n",
-       "3            NaN           NaN             False        NaN     False   \n",
-       "4            NaN           NaN             False        NaN     False   \n",
+       "0            NaN  0.000000e+00             False        NaN     False   \n",
+       "1            NaN  0.000000e+00             False        NaN     False   \n",
+       "2            NaN  0.000000e+00             False        NaN     False   \n",
+       "3            NaN  0.000000e+00             False        NaN     False   \n",
+       "4            NaN  0.000000e+00             False        NaN     False   \n",
        "...          ...           ...               ...        ...       ...   \n",
        "66332        1.0  4.799773e-07             False        NaN     False   \n",
        "66333        1.0  4.799773e-07             False        NaN     False   \n",
@@ -3236,7 +3512,7 @@
        "[66337 rows x 16 columns]"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3250,7 +3526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -3266,7 +3542,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776391850804)>"
+       "<ggplot: (8783949779149)>"
       ]
      },
      "metadata": {},
@@ -3302,7 +3578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -3325,7 +3601,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776389748730)>"
+       "<ggplot: (8783969287051)>"
       ]
      },
      "metadata": {},
@@ -3376,27 +3652,332 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>cell_barcode</th>\n",
+       "      <th>infected</th>\n",
+       "      <th>infecting_viral_tag</th>\n",
+       "      <th>gene</th>\n",
+       "      <th>frac_viral_UMIs</th>\n",
+       "      <th>viral_barcode</th>\n",
+       "      <th>viral_bc_UMIs</th>\n",
+       "      <th>frac_viral_bc_UMIs</th>\n",
+       "      <th>reject_uninfected</th>\n",
+       "      <th>sup_count</th>\n",
+       "      <th>freq_progeny</th>\n",
+       "      <th>in_infected_cell</th>\n",
+       "      <th>n_cell_bc</th>\n",
+       "      <th>gt1_cell</th>\n",
+       "      <th>n_viral_bc</th>\n",
+       "      <th>gt1_viral_bc</th>\n",
+       "      <th>cell_total_frac_viral_bc_UMIs</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AAACCCAGTAACAAGT</td>\n",
+       "      <td>False</td>\n",
+       "      <td>none</td>\n",
+       "      <td>fluHA</td>\n",
+       "      <td>0.000048</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AAACCCATCATTGCTT</td>\n",
+       "      <td>False</td>\n",
+       "      <td>none</td>\n",
+       "      <td>fluHA</td>\n",
+       "      <td>0.000051</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>AAACGAAAGATGTTGA</td>\n",
+       "      <td>False</td>\n",
+       "      <td>none</td>\n",
+       "      <td>fluHA</td>\n",
+       "      <td>0.000204</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>AAACGCTCAAATGATG</td>\n",
+       "      <td>False</td>\n",
+       "      <td>none</td>\n",
+       "      <td>fluHA</td>\n",
+       "      <td>0.000107</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>AAACGCTCATGGACAG</td>\n",
+       "      <td>False</td>\n",
+       "      <td>none</td>\n",
+       "      <td>fluHA</td>\n",
+       "      <td>0.000119</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>66332</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>wt</td>\n",
+       "      <td>fluNA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>TTTTTCCCTTACATAT</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>4.799773e-07</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>66333</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>wt</td>\n",
+       "      <td>fluNA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>TTTTTCTTACGATCAC</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>4.799773e-07</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>66334</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>wt</td>\n",
+       "      <td>fluNA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>TTTTTCTTCGAGATAG</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>4.799773e-06</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>66335</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>wt</td>\n",
+       "      <td>fluNA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>TTTTTGGGATCATTGC</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>9.599545e-07</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>66336</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>wt</td>\n",
+       "      <td>fluNA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>TTTTTTTACTCAGAAT</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>9.599545e-07</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>66337 rows × 17 columns</p>\n",
+       "</div>"
+      ],
       "text/plain": [
-       "NaN         57147\n",
-       "0.000000     4851\n",
-       "0.100567       41\n",
-       "0.113515       35\n",
-       "0.066219       33\n",
-       "            ...  \n",
-       "0.000017        1\n",
-       "0.001482        1\n",
-       "0.000020        1\n",
-       "0.000033        1\n",
-       "0.000036        1\n",
-       "Name: cell_total_frac_viral_bc_UMIs, Length: 1828, dtype: int64"
+       "           cell_barcode infected infecting_viral_tag   gene  frac_viral_UMIs  \\\n",
+       "0      AAACCCAGTAACAAGT    False                none  fluHA         0.000048   \n",
+       "1      AAACCCATCATTGCTT    False                none  fluHA         0.000051   \n",
+       "2      AAACGAAAGATGTTGA    False                none  fluHA         0.000204   \n",
+       "3      AAACGCTCAAATGATG    False                none  fluHA         0.000107   \n",
+       "4      AAACGCTCATGGACAG    False                none  fluHA         0.000119   \n",
+       "...                 ...      ...                 ...    ...              ...   \n",
+       "66332               NaN      NaN                  wt  fluNA              NaN   \n",
+       "66333               NaN      NaN                  wt  fluNA              NaN   \n",
+       "66334               NaN      NaN                  wt  fluNA              NaN   \n",
+       "66335               NaN      NaN                  wt  fluNA              NaN   \n",
+       "66336               NaN      NaN                  wt  fluNA              NaN   \n",
+       "\n",
+       "          viral_barcode  viral_bc_UMIs  frac_viral_bc_UMIs reject_uninfected  \\\n",
+       "0                   NaN            0.0                 0.0             False   \n",
+       "1                   NaN            0.0                 0.0             False   \n",
+       "2                   NaN            0.0                 0.0             False   \n",
+       "3                   NaN            0.0                 0.0             False   \n",
+       "4                   NaN            0.0                 0.0             False   \n",
+       "...                 ...            ...                 ...               ...   \n",
+       "66332  TTTTTCCCTTACATAT            NaN                 NaN               NaN   \n",
+       "66333  TTTTTCTTACGATCAC            NaN                 NaN               NaN   \n",
+       "66334  TTTTTCTTCGAGATAG            NaN                 NaN               NaN   \n",
+       "66335  TTTTTGGGATCATTGC            NaN                 NaN               NaN   \n",
+       "66336  TTTTTTTACTCAGAAT            NaN                 NaN               NaN   \n",
+       "\n",
+       "       sup_count  freq_progeny  in_infected_cell  n_cell_bc  gt1_cell  \\\n",
+       "0            NaN  0.000000e+00             False        NaN     False   \n",
+       "1            NaN  0.000000e+00             False        NaN     False   \n",
+       "2            NaN  0.000000e+00             False        NaN     False   \n",
+       "3            NaN  0.000000e+00             False        NaN     False   \n",
+       "4            NaN  0.000000e+00             False        NaN     False   \n",
+       "...          ...           ...               ...        ...       ...   \n",
+       "66332        1.0  4.799773e-07             False        NaN     False   \n",
+       "66333        1.0  4.799773e-07             False        NaN     False   \n",
+       "66334       10.0  4.799773e-06             False        NaN     False   \n",
+       "66335        2.0  9.599545e-07             False        NaN     False   \n",
+       "66336        2.0  9.599545e-07             False        NaN     False   \n",
+       "\n",
+       "       n_viral_bc  gt1_viral_bc  cell_total_frac_viral_bc_UMIs  \n",
+       "0             NaN         False                            0.0  \n",
+       "1             NaN         False                            0.0  \n",
+       "2             NaN         False                            0.0  \n",
+       "3             NaN         False                            0.0  \n",
+       "4             NaN         False                            0.0  \n",
+       "...           ...           ...                            ...  \n",
+       "66332         NaN         False                            NaN  \n",
+       "66333         NaN         False                            NaN  \n",
+       "66334         NaN         False                            NaN  \n",
+       "66335         NaN         False                            NaN  \n",
+       "66336         NaN         False                            NaN  \n",
+       "\n",
+       "[66337 rows x 17 columns]"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3416,7 +3997,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -3436,7 +4017,7 @@
        "Name: cell_total_frac_viral_bc_UMIs, Length: 1828, dtype: int64"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3454,7 +4035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -3511,7 +4092,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -3532,7 +4113,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -3553,7 +4134,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -3574,7 +4155,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -3595,7 +4176,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -3763,11 +4344,11 @@
        "66336  TTTTTTTACTCAGAAT            NaN                 NaN               NaN   \n",
        "\n",
        "       sup_count  freq_progeny  in_infected_cell  n_cell_bc  gt1_cell  \\\n",
-       "0            NaN           NaN             False        NaN     False   \n",
-       "1            NaN           NaN             False        NaN     False   \n",
-       "2            NaN           NaN             False        NaN     False   \n",
-       "3            NaN           NaN             False        NaN     False   \n",
-       "4            NaN           NaN             False        NaN     False   \n",
+       "0            NaN  0.000000e+00             False        NaN     False   \n",
+       "1            NaN  0.000000e+00             False        NaN     False   \n",
+       "2            NaN  0.000000e+00             False        NaN     False   \n",
+       "3            NaN  0.000000e+00             False        NaN     False   \n",
+       "4            NaN  0.000000e+00             False        NaN     False   \n",
        "...          ...           ...               ...        ...       ...   \n",
        "66332        1.0  4.799773e-07             False        NaN     False   \n",
        "66333        1.0  4.799773e-07             False        NaN     False   \n",
@@ -3804,7 +4385,7 @@
        "[66337 rows x 18 columns]"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3828,7 +4409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -3886,7 +4467,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -3908,7 +4489,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -3930,7 +4511,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -3952,7 +4533,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -3974,7 +4555,7 @@
        "      <td>0.0</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>0.000000e+00</td>\n",
        "      <td>False</td>\n",
        "      <td>NaN</td>\n",
        "      <td>False</td>\n",
@@ -4149,11 +4730,11 @@
        "66336  TTTTTTTACTCAGAAT            NaN                 NaN               NaN   \n",
        "\n",
        "       sup_count  freq_progeny  in_infected_cell  n_cell_bc  gt1_cell  \\\n",
-       "0            NaN           NaN             False        NaN     False   \n",
-       "1            NaN           NaN             False        NaN     False   \n",
-       "2            NaN           NaN             False        NaN     False   \n",
-       "3            NaN           NaN             False        NaN     False   \n",
-       "4            NaN           NaN             False        NaN     False   \n",
+       "0            NaN  0.000000e+00             False        NaN     False   \n",
+       "1            NaN  0.000000e+00             False        NaN     False   \n",
+       "2            NaN  0.000000e+00             False        NaN     False   \n",
+       "3            NaN  0.000000e+00             False        NaN     False   \n",
+       "4            NaN  0.000000e+00             False        NaN     False   \n",
        "...          ...           ...               ...        ...       ...   \n",
        "66332        1.0  4.799773e-07             False        NaN     False   \n",
        "66333        1.0  4.799773e-07             False        NaN     False   \n",
@@ -4190,7 +4771,7 @@
        "[66337 rows x 19 columns]"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4214,7 +4795,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -4230,7 +4811,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776402523992)>"
+       "<ggplot: (8783969307935)>"
       ]
      },
      "metadata": {},
@@ -4260,7 +4841,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -4283,7 +4864,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776403657710)>"
+       "<ggplot: (8783969040505)>"
       ]
      },
      "metadata": {},
@@ -4310,31 +4891,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "NaN         57147\n",
-       "0.000000     4851\n",
-       "0.100567       41\n",
-       "0.113515       35\n",
-       "0.066219       33\n",
-       "            ...  \n",
-       "0.000017        1\n",
-       "0.001482        1\n",
-       "0.000020        1\n",
-       "0.000033        1\n",
-       "0.000036        1\n",
-       "Name: cell_total_frac_viral_bc_UMIs, Length: 1828, dtype: int64"
-      ]
-     },
-     "execution_count": 42,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": []
   },
   {
@@ -4346,7 +4905,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -4357,7 +4916,7 @@
        "Name: top_viral_bc, dtype: int64"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4369,7 +4928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -4392,7 +4951,7 @@
     {
      "data": {
       "text/plain": [
-       "<ggplot: (8776391631629)>"
+       "<ggplot: (8783947611335)>"
       ]
      },
      "metadata": {},


### PR DESCRIPTION
@jbloom Please reivew and merge this code when you get a chance. This pull request does two things:
1. It fixes the code that ranks viral barcodes by abundance for each cell-gene. This is simply based on the code you showed me. Note that you do not need to sort the dataframe before using the rank function.
2. If a viral barcode is seen in the transcriptome but not the supernatant, it sets the supernatant frequency to 0. Previously, I have been leaving these as `NA` values, but we can meaningfully say that the frequency is 0.