### PR TITLE
Added saturation calculation

### DIFF
--- a/notebooks/viral_barcodes_in_progeny.py.ipynb
+++ b/notebooks/viral_barcodes_in_progeny.py.ipynb
@@ -362,7 +362,7 @@
     "\n",
     "saturation_df['saturation'] = 1 - saturation_df['uniqueness']\n",
     "\n",
-    "display(saturation)"
+    "display(saturation_df)"
    ]
   },
   {


### PR DESCRIPTION
@jbloom Please review and merge.

This pull request calculates the sequencing saturation for progeny samples. The formula for this is given in the 10X documentation here: https://kb.10xgenomics.com/hc/en-us/articles/115003646912-How-is-sequencing-saturation-calculated-

Conceptually, I am calculating the fraction of reads that contain a viral barcode that was already seen in another read. Usefully, the inverse of this value provides the average number of reads required to identify a new viral barcode.

The publication sample (scProgenyProduction_trial3) has sequencing saturation > 99% for all samples, so no more sequencing is required.