### PR TITLE
Checked cell barcodes for presence in transcriptome data

### DIFF
--- a/notebooks/pacbio_consensus_sequences.py.ipynb
+++ b/notebooks/pacbio_consensus_sequences.py.ipynb
@@ -17,7 +17,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:42:41.126096Z",
+     "iopub.status.busy": "2021-08-28T08:42:41.125090Z",
+     "iopub.status.idle": "2021-08-28T08:42:45.087421Z",
+     "shell.execute_reply": "2021-08-28T08:42:45.088277Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from Bio.Seq import Seq\n",
@@ -36,7 +43,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:42:45.092332Z",
+     "iopub.status.busy": "2021-08-28T08:42:45.091167Z",
+     "iopub.status.idle": "2021-08-28T08:42:45.095902Z",
+     "shell.execute_reply": "2021-08-28T08:42:45.096513Z"
+    }
+   },
    "outputs": [],
    "source": [
     "mutation_df = snakemake.input.mutation_df\n",
@@ -47,7 +61,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:42:45.099155Z",
+     "iopub.status.busy": "2021-08-28T08:42:45.098369Z",
+     "iopub.status.idle": "2021-08-28T08:42:58.470117Z",
+     "shell.execute_reply": "2021-08-28T08:42:58.470773Z"
+    }
+   },
    "outputs": [],
    "source": [
     "mutations = pd.read_csv(mutation_df, compression='gzip', low_memory=False)\n",
@@ -64,7 +85,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:42:58.474252Z",
+     "iopub.status.busy": "2021-08-28T08:42:58.473298Z",
+     "iopub.status.idle": "2021-08-28T08:43:11.012537Z",
+     "shell.execute_reply": "2021-08-28T08:43:11.013020Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# create column that removed termini3 mutations\n",
@@ -79,7 +107,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:11.015294Z",
+     "iopub.status.busy": "2021-08-28T08:43:11.014644Z",
+     "iopub.status.idle": "2021-08-28T08:43:12.566468Z",
+     "shell.execute_reply": "2021-08-28T08:43:12.567016Z"
+    }
+   },
    "outputs": [],
    "source": [
     "filter_col = [col for col in mutations\n",
@@ -92,7 +127,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:12.569710Z",
+     "iopub.status.busy": "2021-08-28T08:43:12.568928Z",
+     "iopub.status.idle": "2021-08-28T08:43:12.583006Z",
+     "shell.execute_reply": "2021-08-28T08:43:12.583641Z"
+    }
+   },
    "outputs": [],
    "source": [
     "col_one_list = mutations['cellbarcode_sequence'].tolist()"
@@ -101,7 +143,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:12.586633Z",
+     "iopub.status.busy": "2021-08-28T08:43:12.585754Z",
+     "iopub.status.idle": "2021-08-28T08:43:15.072517Z",
+     "shell.execute_reply": "2021-08-28T08:43:15.073025Z"
+    }
+   },
    "outputs": [],
    "source": [
     "barcode_list = []\n",
@@ -119,34 +168,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:15.075426Z",
+     "iopub.status.busy": "2021-08-28T08:43:15.074750Z",
+     "iopub.status.idle": "2021-08-28T08:43:19.231874Z",
+     "shell.execute_reply": "2021-08-28T08:43:19.232475Z"
+    }
+   },
    "outputs": [],
    "source": [
     "df_merged = pd.merge(mutations, cell_barcodes,\n",
     "                     how='left', left_on=['cellbarcode_rv'],\n",
     "                     right_on=['cell_barcode'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## CCS with valid cell barcodes\n",
-    "\n",
-    "We want to count the number of CCS with cell barcodes that are found in the transcriptome data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print('How many CCS have a cell barcode that is also '\n",
-    "      'found in the transcriptome data?')\n",
-    "(mutations['cellbarcode_rv']\n",
-    " .isin(cell_barcodes['cell_barcode'])\n",
-    " .value_counts())"
    ]
   },
   {
@@ -159,7 +193,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:19.235328Z",
+     "iopub.status.busy": "2021-08-28T08:43:19.234498Z",
+     "iopub.status.idle": "2021-08-28T08:43:20.813357Z",
+     "shell.execute_reply": "2021-08-28T08:43:20.813851Z"
+    }
+   },
    "outputs": [],
    "source": [
     "df_merged = df_merged.loc[df_merged['tag_status'] != 'chimeric tags']"
@@ -168,7 +209,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:20.816579Z",
+     "iopub.status.busy": "2021-08-28T08:43:20.815726Z",
+     "iopub.status.idle": "2021-08-28T08:43:20.945472Z",
+     "shell.execute_reply": "2021-08-28T08:43:20.946016Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# change bools to yes/no as flake complains on later filtering\n",
@@ -182,13 +230,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## CCSs in infected and uninfected cells"
+    "## CCS with valid cell barcodes\n",
+    "We want to count the number of CCS with cell barcodes that are found in the transcriptome data"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('How many CCS have a cell barcode that is also found in the transcriptome data?')\n",
+    "mutations['cellbarcode_rv'].isin(cell_barcodes['cell_barcode']).value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CCSs in infected and uninfected cells"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:20.948854Z",
+     "iopub.status.busy": "2021-08-28T08:43:20.947996Z",
+     "iopub.status.idle": "2021-08-28T08:43:21.059930Z",
+     "shell.execute_reply": "2021-08-28T08:43:21.060483Z"
+    }
+   },
    "outputs": [],
    "source": [
     "print('How many CCSs are called in infected vs uninfected cells:')\n",
@@ -205,7 +278,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:21.063511Z",
+     "iopub.status.busy": "2021-08-28T08:43:21.062638Z",
+     "iopub.status.idle": "2021-08-28T08:43:21.177239Z",
+     "shell.execute_reply": "2021-08-28T08:43:21.177737Z"
+    }
+   },
    "outputs": [],
    "source": [
     "uninfected = df_merged.loc[df_merged['infected'] == 'No']\n",
@@ -220,7 +300,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:21.180072Z",
+     "iopub.status.busy": "2021-08-28T08:43:21.179400Z",
+     "iopub.status.idle": "2021-08-28T08:43:21.714694Z",
+     "shell.execute_reply": "2021-08-28T08:43:21.715243Z"
+    }
+   },
    "outputs": [],
    "source": [
     "p = (\n",
@@ -251,7 +338,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:21.718218Z",
+     "iopub.status.busy": "2021-08-28T08:43:21.717369Z",
+     "iopub.status.idle": "2021-08-28T08:43:22.276397Z",
+     "shell.execute_reply": "2021-08-28T08:43:22.276891Z"
+    }
+   },
    "outputs": [],
    "source": [
     "infected = df_merged.loc[df_merged['infected'] == 'Yes']\n",
@@ -270,7 +364,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:22.279571Z",
+     "iopub.status.busy": "2021-08-28T08:43:22.278692Z",
+     "iopub.status.idle": "2021-08-28T08:43:22.669085Z",
+     "shell.execute_reply": "2021-08-28T08:43:22.669507Z"
+    }
+   },
    "outputs": [],
    "source": [
     "p = (\n",
@@ -308,7 +409,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:22.671793Z",
+     "iopub.status.busy": "2021-08-28T08:43:22.671142Z",
+     "iopub.status.idle": "2021-08-28T08:43:24.354068Z",
+     "shell.execute_reply": "2021-08-28T08:43:24.354510Z"
+    }
+   },
    "outputs": [],
    "source": [
     "UMI_count = (\n",
@@ -323,7 +431,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:24.356872Z",
+     "iopub.status.busy": "2021-08-28T08:43:24.356169Z",
+     "iopub.status.idle": "2021-08-28T08:43:28.015929Z",
+     "shell.execute_reply": "2021-08-28T08:43:28.016371Z"
+    }
+   },
    "outputs": [],
    "source": [
     "p = (\n",
@@ -345,7 +460,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:28.018652Z",
+     "iopub.status.busy": "2021-08-28T08:43:28.017996Z",
+     "iopub.status.idle": "2021-08-28T08:43:28.038012Z",
+     "shell.execute_reply": "2021-08-28T08:43:28.038451Z"
+    }
+   },
    "outputs": [],
    "source": [
     "UMI_count_table = (\n",
@@ -375,7 +497,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:28.041208Z",
+     "iopub.status.busy": "2021-08-28T08:43:28.040236Z",
+     "iopub.status.idle": "2021-08-28T08:43:32.242020Z",
+     "shell.execute_reply": "2021-08-28T08:43:32.242445Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# remove duplicate mutation strings\n",
@@ -397,7 +526,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:32.244745Z",
+     "iopub.status.busy": "2021-08-28T08:43:32.244084Z",
+     "iopub.status.idle": "2021-08-28T08:43:45.342522Z",
+     "shell.execute_reply": "2021-08-28T08:43:45.343021Z"
+    }
+   },
    "outputs": [],
    "source": [
     "infected = infected.replace(np.nan, '', regex=True)\n",
@@ -422,40 +558,51 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:43:45.345508Z",
+     "iopub.status.busy": "2021-08-28T08:43:45.344849Z",
+     "iopub.status.idle": "2021-08-28T08:45:05.163035Z",
+     "shell.execute_reply": "2021-08-28T08:45:05.163568Z"
+    }
+   },
    "outputs": [],
    "source": [
     "consensus, dropped = alignparse.consensus.simple_mutconsensus(\n",
     "    infected,\n",
-    "    group_cols=['cellbarcode_sequence', 'transcript', 'UMI_sequence'],\n",
+    "    group_cols=['cellbarcode_rv', 'transcript', 'UMI_sequence'],\n",
     "    mutation_col='all_mutations_delsMerge',\n",
     "    max_sub_diffs=5,\n",
     "    max_indel_diffs=10,\n",
     "    max_minor_sub_frac=0.3,\n",
     "    max_minor_indel_frac=0.3,\n",
     "    support_col='variant_call_support'\n",
-    ")"
+    ")\n",
+    "\n",
+    "consensus = (\n",
+    "    consensus\n",
+    "    .rename(columns={'cellbarcode_rv': 'cellbarcode_sequence'}))\n",
+    "dropped = (\n",
+    "    dropped\n",
+    "    .rename(columns={'cellbarcode_rv': 'cellbarcode_sequence'}))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:45:05.166142Z",
+     "iopub.status.busy": "2021-08-28T08:45:05.165470Z",
+     "iopub.status.idle": "2021-08-28T08:45:05.170507Z",
+     "shell.execute_reply": "2021-08-28T08:45:05.171031Z"
+    }
+   },
    "outputs": [],
    "source": [
     "print('We dropped', len(dropped.index),\n",
     "      'UMIs, which were supported by',\n",
     "      dropped['nseqs'].sum(), 'CSSs')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#reverse complement cell barcode\n",
-    "consensus['cellbarcode_sequence'] = consensus['cellbarcode_sequence'].apply(lambda x: str(Seq(x).complement())[::-1])"
    ]
   },
   {
@@ -468,7 +615,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-08-28T08:45:05.982021Z",
+     "iopub.status.busy": "2021-08-28T08:45:05.981358Z",
+     "iopub.status.idle": "2021-08-28T08:45:12.775114Z",
+     "shell.execute_reply": "2021-08-28T08:45:12.775621Z"
+    }
+   },
    "outputs": [],
    "source": [
     "consensus.to_csv(consensus_UMI_mutations,\n",
@@ -492,7 +646,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pull request checks the concordance between cell barcodes in the transcriptome data and in the PacBio data. It simply counts the number of CCS where the cell barcode is also found in the list of transcriptome cell barcodes.

@Bernadetadad I thought the `pacbio_consensus_sequences.py.ipynb` notebook might be the best place for this, since similar calculations are done there (e.g. CCS in infected vs. uninfected cells). Would you please review this and let me know what you think?