### PR TITLE
Gene presence simple cutoff

### DIFF
--- a/notebooks/viral_gene_presence.py.ipynb
+++ b/notebooks/viral_gene_presence.py.ipynb
@@ -577,6 +577,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Merge limit values into `viral_gene_expression_long` df."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viral_gene_expression_long = pd.merge(\n",
+    "    left=viral_gene_expression_long,\n",
+    "    right=limit,\n",
+    "    on='gene',\n",
+    "    how='left',\n",
+    "    validate='many_to_one'\n",
+    ")\n",
+    "\n",
+    "display(viral_gene_expression_long)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Label genes as absent if they fall below this limit."
    ]
   },


### PR DESCRIPTION
This pull request changes the way we call viral genes as present or absent in each cell. It replaces a statistical test with a simple cutoff. This has little effect on the results and is more simple.

The threshold is applied to the **fraction** of UMIs in each cell. The threshold is set at the 99th percentile observed in uninfected cells for genes with high expression levels. For genes with low expression levels (e.g. pol complex), cells with any transcripts detected are called as expressing the gene.

@andrewwbutler Would you please skim this code and merge when you have a chance?

